### PR TITLE
Add unit tests to backend's functions

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -71,6 +71,9 @@
     "typescript-eslint": "^8.20.0"
   },
   "jest": {
+    "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     "moduleFileExtensions": [
       "js",
       "json",

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -1,0 +1,186 @@
+process.env.JWT_SECRET = 'test-secret';
+import {
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+import * as jwt from 'jsonwebtoken';
+import { AuthService } from './auth.service';
+import { PrismaService } from '../prisma.service';
+
+// Mockujemy zewnętrzne biblioteki — nie wywołujemy prawdziwego bcrypt/jwt
+jest.mock('bcrypt');
+jest.mock('jsonwebtoken');
+
+const mockPrisma = {
+  user: {
+    findUnique: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  afterAll(() => {
+    delete process.env.JWT_SECRET;
+  });
+
+  // ──────────────────────────────────────────────
+  // register
+  // ──────────────────────────────────────────────
+  describe('register', () => {
+    const dto = {
+      mail: 'test@example.com',
+      password: 'haslo123',
+      name: 'Jan',
+      lastname: 'Kowalski',
+    };
+
+    it('powinno zarejestrować nowego użytkownika', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null); // email wolny
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed_password');
+      mockPrisma.user.create.mockResolvedValue({ id: 1, name: 'Jan', is_Admin: false });
+      (jwt.sign as jest.Mock).mockReturnValue('fake-token');
+
+      const result = await service.register(dto);
+
+      expect(result.id).toBe(1);
+      expect(result.name).toBe('Jan');
+      expect(result.token).toBe('fake-token');
+    });
+
+    it('powinno rzucić ConflictException gdy email jest zajęty', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 5, mail: 'test@example.com' });
+
+      await expect(service.register(dto)).rejects.toThrow(ConflictException);
+    });
+
+    it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd przy sprawdzeniu emaila', async () => {
+      mockPrisma.user.findUnique.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.register(dto)).rejects.toThrow(InternalServerErrorException);
+    });
+
+    it('powinno hashować hasło przed zapisem', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      (bcrypt.hash as jest.Mock).mockResolvedValue('hashed_password');
+      mockPrisma.user.create.mockResolvedValue({ id: 1, name: 'Jan', is_Admin: false });
+      (jwt.sign as jest.Mock).mockReturnValue('fake-token');
+
+      await service.register(dto);
+
+      expect(bcrypt.hash).toHaveBeenCalledWith('haslo123', 12);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // login
+  // ──────────────────────────────────────────────
+  describe('login', () => {
+    const dto = { mail: 'test@example.com', password: 'haslo123' };
+
+    it('powinno zalogować użytkownika z poprawnymi danymi', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Jan',
+        password: 'hashed',
+        is_Admin: false,
+        is_Banned: false,
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+      (jwt.sign as jest.Mock).mockReturnValue('fake-token');
+
+      const result = await service.login(dto);
+
+      expect(result.token).toBe('fake-token');
+      expect(result.is_Admin).toBe(false);
+    });
+
+    it('powinno rzucić UnauthorizedException gdy użytkownik nie istnieje', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.login(dto)).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('powinno rzucić UnauthorizedException gdy hasło jest błędne', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Jan',
+        password: 'hashed',
+        is_Admin: false,
+        is_Banned: false,
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false); // złe hasło
+
+      await expect(service.login(dto)).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // removeUser
+  // ──────────────────────────────────────────────
+  describe('removeUser', () => {
+    it('powinno oznaczyć użytkownika jako usuniętego', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, name: 'Jan', is_Removed: false });
+      mockPrisma.user.update.mockResolvedValue({ id: 1, is_Removed: true });
+
+      const result = await service.removeUser(1);
+
+      expect(result.is_Removed).toBe(true);
+    });
+
+    it('powinno rzucić NotFoundException gdy użytkownik nie istnieje', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.removeUser(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // verifyPassword
+  // ──────────────────────────────────────────────
+  describe('verifyPassword', () => {
+    it('powinno zwrócić true dla poprawnego hasła', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ password: 'hashed' });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.verifyPassword(1, 'mojeHaslo');
+
+      expect(result).toBe(true);
+    });
+
+    it('powinno zwrócić false dla błędnego hasła', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ password: 'hashed' });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      const result = await service.verifyPassword(1, 'zleHaslo');
+
+      expect(result).toBe(false);
+    });
+
+    it('powinno rzucić NotFoundException gdy użytkownik nie istnieje', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.verifyPassword(999, 'haslo')).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/book/book.service.spec.ts
+++ b/backend/src/book/book.service.spec.ts
@@ -1,0 +1,190 @@
+import {
+  BadRequestException,
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BookService } from './book.service';
+import { PrismaService } from '../prisma.service';
+
+// Mockujemy cały PrismaService — nie potrzebujemy prawdziwej bazy danych
+const mockPrisma = {
+  book: {
+    findFirst: jest.fn(),
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+    create: jest.fn(),
+  },
+  author: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+  },
+  publisher: {
+    findFirst: jest.fn(),
+    create: jest.fn(),
+  },
+  copy: {
+    count: jest.fn(),
+  },
+};
+
+describe('BookService', () => {
+  let service: BookService;
+
+  beforeEach(async () => {
+    // Resetujemy wszystkie mocki przed każdym testem
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BookService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<BookService>(BookService);
+  });
+
+  // ──────────────────────────────────────────────
+  // addBook
+  // ──────────────────────────────────────────────
+  describe('addBook', () => {
+    const dto = {
+      title: 'Wiedźmin',
+      year: 1990,
+      cover: 'url',
+      ISBN: '1234567890123',
+      publisher_name: 'SuperNOWA',
+      authors: [{ author_name: 'Andrzej', author_lastname: 'Sapkowski' }],
+    };
+
+    it('powinno dodać książkę jeśli tytuł i ISBN są unikalne', async () => {
+      mockPrisma.book.findFirst.mockResolvedValue(null); // brak duplikatu
+      mockPrisma.author.findFirst.mockResolvedValue({ id_author: 1, author_name: 'Andrzej', author_lastname: 'Sapkowski' });
+      mockPrisma.publisher.findFirst.mockResolvedValue({ id_publisher: 1, publisher_name: 'SuperNOWA' });
+      mockPrisma.book.create.mockResolvedValue({ id_book: 1, title: 'Wiedźmin' });
+
+      const result = await service.addBook(dto);
+
+      expect(result).toEqual({ id_book: 1, title: 'Wiedźmin' });
+      expect(mockPrisma.book.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('powinno rzucić ConflictException jeśli książka już istnieje', async () => {
+      mockPrisma.book.findFirst.mockResolvedValue({ id_book: 5, title: 'Wiedźmin' });
+
+      await expect(service.addBook(dto)).rejects.toThrow(ConflictException);
+    });
+
+    it('powinno rzucić BadRequestException gdy ISBN ma nieprawidłową długość', async () => {
+      mockPrisma.book.findFirst.mockResolvedValue(null);
+      const badDto = { ...dto, ISBN: '123' }; // za krótki ISBN
+
+      await expect(service.addBook(badDto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd', async () => {
+      mockPrisma.book.findFirst.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.addBook(dto)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // searchBooks
+  // ──────────────────────────────────────────────
+  describe('searchBooks', () => {
+    it('powinno zwrócić paginowaną listę książek', async () => {
+      mockPrisma.book.count.mockResolvedValue(25);
+      mockPrisma.book.findMany.mockResolvedValue([
+        { id_book: 1, title: 'Wiedźmin', year: 1990, ISBN: '1234567890123', cover: null, authors: [] },
+      ]);
+
+      const result = await service.searchBooks(1, 10);
+
+      expect(result.meta.total).toBe(25);
+      expect(result.meta.totalPages).toBe(3);
+      expect(result.data).toHaveLength(1);
+    });
+
+    it('powinno ograniczyć limit do 100', async () => {
+      mockPrisma.book.count.mockResolvedValue(5);
+      mockPrisma.book.findMany.mockResolvedValue([]);
+
+      const result = await service.searchBooks(1, 999);
+
+      expect(result.meta.limit).toBe(100);
+    });
+
+    it('powinno obsłużyć stronę 0 jako stronę 1', async () => {
+      mockPrisma.book.count.mockResolvedValue(5);
+      mockPrisma.book.findMany.mockResolvedValue([]);
+
+      const result = await service.searchBooks(0, 10);
+
+      expect(result.meta.page).toBe(1);
+    });
+
+    it('powinno rzucić InternalServerErrorException gdy count się nie powiedzie', async () => {
+      mockPrisma.book.count.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.searchBooks(1, 10)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // getBook
+  // ──────────────────────────────────────────────
+  describe('getBook', () => {
+    it('powinno zwrócić książkę z liczbą kopii', async () => {
+      mockPrisma.book.findUnique.mockResolvedValue({
+        id_book: 1,
+        title: 'Wiedźmin',
+        year: 1990,
+        cover: null,
+        ISBN: '1234567890123',
+        publisher_id: 1,
+        _count: { copies: 3 },
+      });
+      mockPrisma.copy.count.mockResolvedValue(2); // 2 dostępne kopie
+
+      const result = await service.getBook(1);
+
+      expect(result.totalCopies).toBe(3);
+      expect(result.availableCopies).toBe(2);
+    });
+
+    it('powinno rzucić NotFoundException gdy książka nie istnieje', async () => {
+      mockPrisma.book.findUnique.mockResolvedValue(null);
+
+      await expect(service.getBook(999)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // getOrAddAuthor
+  // ──────────────────────────────────────────────
+  describe('getOrAddAuthor', () => {
+    it('powinno zwrócić istniejącego autora', async () => {
+      const existingAuthor = { id_author: 1, author_name: 'Andrzej', author_lastname: 'Sapkowski' };
+      mockPrisma.author.findFirst.mockResolvedValue(existingAuthor);
+
+      const result = await service.getOrAddAuthor('Andrzej', 'Sapkowski');
+
+      expect(result).toEqual(existingAuthor);
+      expect(mockPrisma.author.create).not.toHaveBeenCalled();
+    });
+
+    it('powinno stworzyć nowego autora gdy nie istnieje', async () => {
+      mockPrisma.author.findFirst.mockResolvedValue(null);
+      mockPrisma.author.create.mockResolvedValue({ id_author: 2, author_name: 'Nowy', author_lastname: 'Autor' });
+
+      const result = await service.getOrAddAuthor('Nowy', 'Autor');
+
+      expect(result.id_author).toBe(2);
+      expect(mockPrisma.author.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/backend/src/loan/loan.service.spec.ts
+++ b/backend/src/loan/loan.service.spec.ts
@@ -1,0 +1,146 @@
+import {
+  ConflictException,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { LoanService } from './loan.service';
+import { PrismaService } from '../prisma.service';
+
+const mockPrisma = {
+  copy: {
+    findUnique: jest.fn(),
+  },
+  loan: {
+    findFirst: jest.fn(),
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+};
+
+describe('LoanService', () => {
+  let service: LoanService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LoanService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<LoanService>(LoanService);
+  });
+
+  // ──────────────────────────────────────────────
+  // loanBook
+  // ──────────────────────────────────────────────
+  describe('loanBook', () => {
+    it('powinno wypożyczyć dostępną kopię', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, is_actual: true });
+      mockPrisma.loan.findFirst.mockResolvedValue(null); // brak aktywnego wypożyczenia
+      mockPrisma.loan.create.mockResolvedValue({ copy_id: 1, start_date: new Date() });
+
+      const result = await service.loanBook(42, 1);
+
+      expect(result.copy_id).toBe(1);
+      expect(mockPrisma.loan.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('powinno rzucić NotFoundException gdy kopia nie istnieje', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue(null);
+
+      await expect(service.loanBook(42, 999)).rejects.toThrow(NotFoundException);
+    });
+
+    it('powinno rzucić NotFoundException gdy kopia jest nieaktualna (usunięta)', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, is_actual: false });
+
+      await expect(service.loanBook(42, 1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('powinno rzucić ConflictException gdy kopia jest już wypożyczona', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, is_actual: true });
+      mockPrisma.loan.findFirst.mockResolvedValue({ id_loan: 99, copy_id: 1, return_date: null }); // aktywne wypożyczenie
+
+      await expect(service.loanBook(42, 1)).rejects.toThrow(ConflictException);
+    });
+
+    it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd przy szukaniu kopii', async () => {
+      mockPrisma.copy.findUnique.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.loanBook(42, 1)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // returnBook
+  // ──────────────────────────────────────────────
+  describe('returnBook', () => {
+    it('powinno zwrócić książkę gdy istnieje aktywne wypożyczenie', async () => {
+      const returnDate = new Date();
+      mockPrisma.loan.findFirst.mockResolvedValue({ id_loan: 10, user_id: 42, copy_id: 1, return_date: null });
+      mockPrisma.loan.update.mockResolvedValue({ copy_id: 1, return_date: returnDate });
+
+      const result = await service.returnBook(42, 1);
+
+      expect(result.return_date).toBeDefined();
+      expect(mockPrisma.loan.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id_loan: 10 } }),
+      );
+    });
+
+    it('powinno rzucić NotFoundException gdy brak aktywnego wypożyczenia', async () => {
+      mockPrisma.loan.findFirst.mockResolvedValue(null);
+
+      await expect(service.returnBook(42, 1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('powinno rzucić InternalServerErrorException gdy update się nie powiedzie', async () => {
+      mockPrisma.loan.findFirst.mockResolvedValue({ id_loan: 10, user_id: 42, copy_id: 1, return_date: null });
+      mockPrisma.loan.update.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.returnBook(42, 1)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // getUserLoans
+  // ──────────────────────────────────────────────
+  describe('getUserLoans', () => {
+    it('powinno zwrócić historię wypożyczeń użytkownika', async () => {
+      const loans = [
+        {
+          id_loan: 1,
+          copy_id: 1,
+          start_date: new Date('2024-01-01'),
+          return_date: new Date('2024-01-15'),
+          copy: { id_copy: 1, book: { id_book: 1, title: 'Wiedźmin', cover: null, ISBN: '1234567890123' } },
+        },
+      ];
+      mockPrisma.loan.findMany.mockResolvedValue(loans);
+
+      const result = await service.getUserLoans(42);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].copy.book.title).toBe('Wiedźmin');
+    });
+
+    it('powinno zwrócić pustą tablicę gdy użytkownik nie ma wypożyczeń', async () => {
+      mockPrisma.loan.findMany.mockResolvedValue([]);
+
+      const result = await service.getUserLoans(42);
+
+      expect(result).toEqual([]);
+    });
+
+    it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd', async () => {
+      mockPrisma.loan.findMany.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.getUserLoans(42)).rejects.toThrow(InternalServerErrorException);
+    });
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -20,6 +20,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false,
     "strictBindCallApply": false,
-    "noFallthroughCasesInSwitch": false
+    "noFallthroughCasesInSwitch": false,
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
## Opis zmian
Dodano testy jednostkowe do backendu, testy działają na mock czyli taka symulacja bazy danych która zwraca co chcemy i na tej podstawie testujemy funkcje.  POniżej opis czego dotyczą testy. 

addBook — poprawne dodanie, duplikat, zły ISBN, błąd DB
searchBooks — paginacja, limit powyżej 100, strona 0, błąd DB
getBook — zwraca książkę z kopiami, rzuca 404
getOrAddAuthor — zwraca istniejącego / tworzy nowego

loanBook — wypożyczenie, brak kopii, kopia usunięta, kopia zajęta, błąd DB
returnBook — zwrot, brak aktywnego wypożyczenia, błąd DB
getUserLoans — historia, pusta lista, błąd DB

register — rejestracja, duplikat emaila, błąd DB, hashowanie hasła
login — poprawne logowanie, zły email, złe hasło
removeUser — usunięcie użytkownika, 404
verifyPassword — poprawne/złe hasło, 404

## Typ zmiany
- [ ] feat: nowa funkcjonalność
- [ ] fix: naprawa błędu
- [ ] docs: dokumentacja
- [x] chore: porządki, konfiguracja, testy
- [ ] refactor: refaktoryzacja kodu

## Jak przetestowano?
UWAGA WAŻNE: Prosze testować, uruchamiając poleceniem "npm run test" !!!!!!
W przypadku powodzenia dostaniemy informacje że przeszło pozytywnie 35 testów

## Checklist
- [x] Kod działa lokalnie
- [x] Brak błędów lint/typecheck
- [x] Testy przechodzą (jeśli dotyczy)
- [x] Opis PR jest zrozumiały dla reszty zespołu