### PR TITLE
chore/backend Add second parts of tests and fix addCopy endpoint

### DIFF
--- a/backend/src/copy/copy.service.spec.ts
+++ b/backend/src/copy/copy.service.spec.ts
@@ -1,0 +1,279 @@
+import {
+  NotFoundException,
+  BadRequestException
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CopyService } from './copy.service';
+import { PrismaService } from '../prisma.service';
+
+
+const mockPrisma = {
+  copy: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    create: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+  loan: {
+    findUnique: jest.fn(),
+    count: jest.fn(),
+  },
+  book: {
+    findUnique: jest.fn(),
+  }
+};
+
+describe('CopyService', () => {
+  let service: CopyService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CopyService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<CopyService>(CopyService);
+  });
+ 
+    
+    // getCopyIsLoan
+    describe('getCopyIsLoan', () => {
+      it('Sprawdzenie dostępności dostępnej kopii', async () => {
+        mockPrisma.loan.count.mockResolvedValue(4);
+  
+        const result = await service.getCopyIsLoan(1);
+
+        expect(result).toBe(true);
+
+      });
+
+      it('Sprawdzenie dostępności niedostępnej kopii', async () => {
+        mockPrisma.loan.count.mockResolvedValue(0);
+  
+        const result = await service.getCopyIsLoan(1);
+
+        expect(result).toBe(false);
+      });
+
+      
+    });
+
+    // getCopy
+    describe('getCopy', () => {
+      it('Pobranie danych kopii', async () => {
+        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
+                                                    book_id: 1,
+                                                    is_actual: true,
+                                                    is_loan: false,
+                                                    });  
+        mockPrisma.loan.count.mockResolvedValue(0);
+  
+        const result = await service.getCopy(1);
+        if(result !== null){
+            expect(result.id_copy).toBe(1);
+            expect(result.book_id).toBe(1);
+            expect(result.is_actual).toBe(true);
+            expect(result.is_loan).toBe(false);
+        }
+      });
+
+      it('Nie można pobrać danych nieistniejącej kopii', async () => {
+        mockPrisma.copy.findUnique.mockResolvedValue(null);  
+  
+        const result = await service.getCopy(1);
+        
+        expect(result).toBe(null);
+      });
+      
+    });
+  
+    // getBookCopies
+    describe('getBookCopies', () => {
+      const lista = [{id_copy: 8,
+                    book_id: 1,
+                    is_actual: true,
+                    is_loan: true
+                    },
+                    {
+                    id_copy: 13,
+                    book_id: 1,
+                    is_actual: true,
+                    is_loan: true
+                    },
+                    {
+                    id_copy: 25,
+                    book_id: 1,
+                    is_actual: true,
+                    is_loan: true
+                    },
+                    {
+                    id_copy: 35,
+                    book_id: 1,
+                    is_actual: true,
+                    is_loan: true
+                    },];
+
+      it('Pobranie danych o kopiach książki', async () => {
+        mockPrisma.copy.findMany.mockResolvedValue(lista);  
+        mockPrisma.loan.count.mockResolvedValue(2);
+        mockPrisma.copy.count.mockResolvedValue(4);
+  
+        const result = await service.getBookCopies(1, 1, 2);
+        expect(result.data).toHaveLength(4);
+        expect(result.data).toEqual(lista);
+
+        expect(result.meta.page).toBe(1);
+        expect(result.meta.limit).toBe(2);
+        expect(result.meta.total).toBe(4);
+        expect(result.meta.totalPages).toBe(2);
+
+      });
+      
+      it('Pobranie pustej listy przez podanie złej strony', async () => {
+        mockPrisma.copy.findMany.mockResolvedValue([]);  
+        mockPrisma.loan.count.mockResolvedValue(0);
+        mockPrisma.copy.count.mockResolvedValue(0);
+  
+        const result = await service.getBookCopies(1, 3, 2);
+        expect(result.data).toHaveLength(0);
+        expect(result.data).toEqual([]);
+
+        expect(result.meta.page).toBe(3);
+        expect(result.meta.limit).toBe(2);
+        expect(result.meta.total).toBe(0);
+        expect(result.meta.totalPages).toBe(0);
+
+      });
+
+      it('Pobranie danych o kopiach książki, pomimo podania ujemnej strony', async () => {
+        mockPrisma.copy.findMany.mockResolvedValue(lista);  
+        mockPrisma.loan.count.mockResolvedValue(2);
+        mockPrisma.copy.count.mockResolvedValue(4);
+  
+        const result = await service.getBookCopies(1, -10, 2);
+        expect(result.data).toHaveLength(4);
+        expect(result.data).toEqual(lista);
+        
+        expect(result.meta.page).toBe(1);
+        expect(result.meta.limit).toBe(2);
+        expect(result.meta.total).toBe(4);
+        expect(result.meta.totalPages).toBe(2);
+
+      });
+
+      it('Pobranie danych o kopiach książki, pomimo podania ujemnego limitu', async () => {
+        mockPrisma.copy.findMany.mockResolvedValue(lista);  
+        mockPrisma.loan.count.mockResolvedValue(2);
+        mockPrisma.copy.count.mockResolvedValue(4);
+  
+        const result = await service.getBookCopies(1, 1, -10);
+        expect(result.data).toHaveLength(4);
+        expect(result.data).toEqual(lista);
+        
+        expect(result.meta.page).toBe(1);
+        expect(result.meta.limit).toBe(1);
+        expect(result.meta.total).toBe(4);
+        expect(result.meta.totalPages).toBe(4);
+
+      });
+
+      it('Pobranie pustej listy o kopiach książki przez podanie błędnego id', async () => {
+        mockPrisma.copy.findMany.mockResolvedValue([]);  
+        mockPrisma.loan.count.mockResolvedValue(0);
+        mockPrisma.copy.count.mockResolvedValue(0);
+  
+        const result = await service.getBookCopies(99, 1, 1);
+        expect(result.data).toHaveLength(0);
+        expect(result.data).toEqual([]);
+        
+        expect(result.meta.page).toBe(1);
+        expect(result.meta.limit).toBe(1);
+        expect(result.meta.total).toBe(0);
+        expect(result.meta.totalPages).toBe(0);
+
+      });
+
+    });
+
+
+    // addCopy
+    describe('addCopy', () => {
+      it('Utworzenie nowej kopii', async () => {
+        mockPrisma.copy.create.mockResolvedValue({ id_copy: 1, 
+                                                    book_id:1,
+                                                    is_actual: true,
+                                                    is_loan: false,
+                                                    });
+        mockPrisma.loan.count.mockResolvedValue(0);
+        mockPrisma.book.findUnique.mockResolvedValue({id_book:1})
+  
+  
+        const result = await service.addCopy(1);
+      
+        expect(result.id_copy).toBe(1);
+        expect(result.book_id).toBe(1);
+        expect(result.is_actual).toBe(true);
+        expect(result.is_loan).toBe(false);
+      });
+      
+      it('Nie można stworzyć kopii nieistniejącej książki', async () => {
+        mockPrisma.book.findUnique.mockResolvedValue(null);  
+        await expect(service.addCopy(1)).rejects.toThrow(NotFoundException);
+      
+      });
+
+    });
+
+    // removeCopy
+    describe('removeCopy', () => {
+      it('Kopia książki została usunięta', async () => {
+        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
+                                                    book_id:1,
+                                                    is_actual: true,
+                                                    });
+  
+        mockPrisma.copy.update.mockResolvedValue({ id_copy: 1, 
+                                              is_actual: false});
+        mockPrisma.loan.count.mockResolvedValue(0);
+  
+        const result = await service.removeCopy(1);
+      
+        expect(result.id_copy).toBe(1);
+        expect(result.is_actual).toBe(false);
+      });
+      
+      it('Kopia nie może być usunięta, ponieważ jest aktualnie wypożyczona', async () => {
+        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
+                                                    book_id:1,
+                                                    is_actual: true,
+                                                   });
+        mockPrisma.loan.count.mockResolvedValue(3);
+  
+        await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
+      });
+  
+      it('Kopia nie może być usunięta, ponieważ została usunięta już wcześniej', async () => {
+        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
+                                                    book_id:1,
+                                                    is_actual: false,
+                                                   });
+        mockPrisma.loan.count.mockResolvedValue(0);
+  
+        await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
+      });
+
+      it('Nie odnaleziono kopii', async () => {
+        mockPrisma.copy.findUnique.mockResolvedValue(null);
+  
+        await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
+      });
+    });
+
+
+});   

--- a/backend/src/copy/copy.service.ts
+++ b/backend/src/copy/copy.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, NotFoundException, InternalServerErrorException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 
 @Injectable()
@@ -73,6 +73,20 @@ export class CopyService {
   }
 
   async addCopy(id_book: number) {
+    const book = await this.prisma.book
+      .findUnique({
+        where: { id_book: id_book },
+        select: {
+          id_book: true,
+        },
+      }).catch(() => {
+        throw new InternalServerErrorException('Błąd bazy danych');
+      });
+
+    if (!book)
+      throw new NotFoundException(`Książka o id ${id_book} nie istnieje`);
+
+
     const newCopy = await this.prisma.copy.create({
       data: {
         book_id: id_book,

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,0 +1,366 @@
+import {
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as bcrypt from 'bcrypt';
+import { UserService } from './user.service';
+import { PrismaService } from '../prisma.service';
+
+// Dodanie zmockowanego bcrypta
+jest.mock('bcrypt');
+
+const mockPrisma = {
+  user: {
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    findMany: jest.fn(),
+    count: jest.fn(),
+  },
+};
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  // GetUser
+  describe('getUser', () => {
+    it('Zwrócono informacje o użytkowniku', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            mail: 'subiekt@sklep.pl',
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            is_Admin: false,
+                                            is_Banned: false,
+                                            is_Removed: false,
+                                            loans: [],});
+
+      const result = await service.getUser(1);
+      
+      expect(result.id).toBe(1);
+      expect(result.mail).toBe('subiekt@sklep.pl');
+      expect(result.name).toBe('Ignacy');
+      expect(result.lastname).toBe('Rzecki');
+      expect(result.is_Admin).toBe(false);
+      expect(result.is_Banned).toBe(false);
+      expect(result.is_Removed).toBe(false);
+      
+    });
+
+    it('Nie znaleziono użytkownika', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.getUser(1)).rejects.toThrow(NotFoundException);    
+    });
+
+    
+  });
+
+
+  // searchUsers
+  describe('searchUsers', () => {
+    const lista = [{ id: 1, 
+                     name: 'Ignacy', 
+                     lastname: "Rzecki", 
+                     mail: 'subiekt@sklep.pl',
+                     is_Admin: false,
+                     is_Banned: false,
+                     is_Removed: false,},
+                   { id: 2, 
+                     name: 'Stanisław', 
+                     lastname: "Wokulski", 
+                     mail: 'subiekt2@sklep.pl',
+                     is_Admin: false,
+                     is_Banned: false,
+                     is_Removed: false,},
+                   { id: 3, 
+                     name: 'Henryk', 
+                     lastname: "Szlangbaum", 
+                     mail: 'subiekt3@sklep.pl',
+                     is_Admin: false,
+                     is_Banned: false,
+                     is_Removed: false,}];
+
+
+    it('Uzyskanie listy użytkowników z paginacją', async () => {
+       mockPrisma.user.findMany.mockResolvedValue(lista);
+       mockPrisma.user.count.mockResolvedValue(3)
+
+       const result = await service.searchUsers(1, 2);
+    
+      expect(result.data).toHaveLength(3);
+      expect(result.data).toBe(lista);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(3);
+      expect(result.meta.totalPages).toBe(2);
+      
+
+     });
+
+    it('Uzyskanie pustej listy przez źle podaną strone', async () => {
+       mockPrisma.user.findMany.mockResolvedValue([]);
+       mockPrisma.user.count.mockResolvedValue(3);
+
+       const result = await service.searchUsers(3, 2);
+    
+      expect(result.data).toEqual([]);
+
+      expect(result.meta.page).toBe(3);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(3);
+      expect(result.meta.totalPages).toBe(2);
+      
+
+     });
+
+    it('Uzyskanie listy użytkowniku mimo podania ujemnej strony', async () => {
+      mockPrisma.user.findMany.mockResolvedValue(lista);
+      mockPrisma.user.count.mockResolvedValue(3);
+
+      const result = await service.searchUsers(-1, 2);
+    
+      expect(result.data).toBe(lista);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(3);
+      expect(result.meta.totalPages).toBe(2);
+      
+
+     });
+
+    it('Uzyskanie listy użytkowniku mimo podania ujemnego limitu', async () => {
+      mockPrisma.user.findMany.mockResolvedValue(lista);
+      mockPrisma.user.count.mockResolvedValue(3);
+
+      const result = await service.searchUsers(1, -3);
+      
+      expect(result.data).toBe(lista);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(1);
+      expect(result.meta.total).toBe(3);
+      expect(result.meta.totalPages).toBe(3);
+      
+
+     });
+
+    it('Uzyskanie listy użytkowniku wraz z wyszukiwaniem po imieniu', async () => {
+      mockPrisma.user.findMany.mockResolvedValue(lista[0]);
+      mockPrisma.user.count.mockResolvedValue(1);
+
+      const result = await service.searchUsers(1, 2, 'Ign');
+      
+      expect(result.data).toBe(lista[0]);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(1);
+      expect(result.meta.totalPages).toBe(1);
+      
+
+     });
+
+  });
+
+
+  // makeAdmin
+  describe('makeAdmin', () => {
+    it('Użytkownik otrzymał uprawnienia administratora', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            is_Admin: false});
+
+      mockPrisma.user.update.mockResolvedValue({ id: 1, 
+                                            is_Admin: true});
+
+      const result = await service.makeAdmin(1);
+    
+      expect(result.id).toBe(1);
+      expect(result.is_Admin).toBe(true);
+    });
+    
+    it('Użytkownik będący adminem nie jest modyfikowany', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            is_Admin: true});
+
+      const result = await service.makeAdmin(1);
+    
+      expect(result.id).toBe(1);
+      expect(result.is_Admin).toBe(true);
+    });
+    
+    it('Nie odnaleziono użytkownika', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      
+      await expect(service.makeAdmin(1)).rejects.toThrow(NotFoundException);
+    
+    });
+
+  });
+
+  // ban
+  describe('ban', () => {
+    it('Użytkownik został zablokowany', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            is_Banned: false});
+
+      mockPrisma.user.update.mockResolvedValue({ id: 1, 
+                                            is_Banned: true});
+
+      const result = await service.ban(1);
+    
+      expect(result.id).toBe(1);
+      expect(result.is_Banned).toBe(true);
+    });
+    
+    it('Użytkownik zablokowany nie jest modyfikowany', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            is_Banned: true});
+
+      const result = await service.ban(1);
+    
+      expect(result.id).toBe(1);
+      expect(result.is_Banned).toBe(true);
+    });
+    
+    it('Nie odnaleziono użytkownika', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      
+      await expect(service.ban(1)).rejects.toThrow(NotFoundException);
+    
+    });
+
+  });
+
+
+  // unban
+  describe('unban', () => {
+    it('Użytkownik został odblokowany', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            is_Banned: true});
+
+      mockPrisma.user.update.mockResolvedValue({ id: 1, 
+                                            is_Banned: false});
+
+      const result = await service.unban(1);
+    
+      expect(result.id).toBe(1);
+      expect(result.is_Banned).toBe(false);
+    });
+    
+    it('Użytkownik niezablokowany nie jest modyfikowany', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            is_Banned: false});
+
+      const result = await service.unban(1);
+    
+      expect(result.id).toBe(1);
+      expect(result.is_Banned).toBe(false);
+    });
+    
+    it('Nie odnaleziono użytkownika', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      
+      await expect(service.unban(1)).rejects.toThrow(NotFoundException);
+    
+    });
+
+  });
+
+  // updateUser
+  describe('updateUser', () => {
+    const dto = {userId: 1,
+        newName: 'Stanisław',
+        newLastname: 'Wokulski',
+        oldPassword: 'hashed',
+        newPassword: 'newhaslo1234',};
+
+    it('Dane zostały zmienione', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            password: 'hashed'});
+      mockPrisma.user.update.mockResolvedValue({ id: 1,
+                                            name: dto.newName, 
+                                            lastname: dto.newLastname});
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.updateUser(dto.userId, dto.newName, dto.newLastname,
+                                                 dto.oldPassword, dto.newPassword);
+    
+      expect(result.id).toBe(dto.userId);
+      expect(result.name).toBe(dto.newName);
+      expect(result.lastname).toBe(dto.newLastname);
+    });
+    
+    it('Dane zostały zmienione, pomimo podania pustych parametrów nowych danych', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            password: 'hashed'});
+      mockPrisma.user.update.mockResolvedValue({ id: 1,
+                                            name: 'Ignacy', 
+                                            lastname: 'Rzecki'});
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const result = await service.updateUser(dto.userId, '', '',
+                                                 dto.oldPassword, '');
+    
+      expect(result.id).toBe(dto.userId);
+      expect(result.name).toBe('Ignacy');
+      expect(result.lastname).toBe('Rzecki');
+    });
+
+    it('Użytkownik nie istnieje', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+      
+      await expect(service.updateUser(dto.userId, dto.newName, dto.newLastname,
+                                            dto.oldPassword, dto.newPassword))
+                                            .rejects.toThrow(NotFoundException);
+    
+    });
+
+    it('Podano niepoprawne hasło', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
+                                            name: 'Ignacy', 
+                                            lastname: "Rzecki", 
+                                            password: 'hashed'});
+      (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+      await expect(service.updateUser(dto.userId, dto.newName, dto.newLastname,
+                                            dto.oldPassword, dto.newPassword))
+                                            .rejects.toThrow(UnauthorizedException);
+    
+    });
+    
+    
+  });
+
+});   


### PR DESCRIPTION
## Opis zmian
Dodano drugą część testów dla serwisów user i copy. Zmodyfikowano endpoint AddCopy, aby w przypadku, gdy użytkownik próbuje stworzyć kopie książki, która nie istnieje zwracał NotFoundExeption.

## Typ zmiany
- [ ] feat: nowa funkcjonalność
- [x] fix: naprawa błędu
- [ ] docs: dokumentacja
- [x] chore: porządki, konfiguracja
- [ ] refactor: refaktoryzacja kodu

## Jak przetestowano?
Endpoint AddCopy można przetestować w swagerze. Testy można odpalić za pomocą polecenia: npm run test.

## Checklist
- [x] Kod działa lokalnie
- [x] Brak błędów lint/typecheck
- [ ] Testy przechodzą (jeśli dotyczy)
- [x] Opis PR jest zrozumiały dla reszty zespołu