### PR TITLE
Added enpoint test srcipt and delet enpoints

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,7 +7,14 @@ import { CopyModule } from './copy/copy.module';
 import { LoanModule } from './loan/loan.module';
 
 @Module({
-  imports: [HealthModule, AuthModule, UserModule, BookModule, CopyModule,LoanModule],
+  imports: [
+    HealthModule,
+    AuthModule,
+    UserModule,
+    BookModule,
+    CopyModule,
+    LoanModule,
+  ],
   controllers: [],
   providers: [],
 })

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Post,
+  Delete,
   Body,
   Res,
   Req,
@@ -293,4 +294,18 @@ export class AuthController {
     }
     return this.authService.removeUser(parseInt(id));
   }
+
+@Delete('deleteUser/:id')
+@HttpCode(HttpStatus.OK)
+@ApiOperation({
+  summary: 'Trwałe usunięcie użytkownika',
+  description: 'Tylko administrator. Kaskadowo usuwa wypożyczenia.',
+})
+async hardDeleteUser(@Param('id') id: string, @Req() req: Request) {
+  const payload = await this.authService.verifyToken(req);
+  if (!payload.is_Admin) {
+    throw new ForbiddenException('Tylko administrator może trwale usuwać użytkowników');
+  }
+  return this.authService.hardDeleteUser(parseInt(id));
+}
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -295,17 +295,19 @@ export class AuthController {
     return this.authService.removeUser(parseInt(id));
   }
 
-@Delete('deleteUser/:id')
-@HttpCode(HttpStatus.OK)
-@ApiOperation({
-  summary: 'Trwałe usunięcie użytkownika',
-  description: 'Tylko administrator. Kaskadowo usuwa wypożyczenia.',
-})
-async hardDeleteUser(@Param('id') id: string, @Req() req: Request) {
-  const payload = await this.authService.verifyToken(req);
-  if (!payload.is_Admin) {
-    throw new ForbiddenException('Tylko administrator może trwale usuwać użytkowników');
+  @Delete('deleteUser/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Trwałe usunięcie użytkownika',
+    description: 'Tylko administrator. Kaskadowo usuwa wypożyczenia.',
+  })
+  async hardDeleteUser(@Param('id') id: string, @Req() req: Request) {
+    const payload = await this.authService.verifyToken(req);
+    if (!payload.is_Admin) {
+      throw new ForbiddenException(
+        'Tylko administrator może trwale usuwać użytkowników',
+      );
+    }
+    return this.authService.hardDeleteUser(parseInt(id));
   }
-  return this.authService.hardDeleteUser(parseInt(id));
-}
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -28,7 +28,6 @@ describe('AuthService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -58,7 +57,11 @@ describe('AuthService', () => {
     it('powinno zarejestrować nowego użytkownika', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null); // email wolny
       (bcrypt.hash as jest.Mock).mockResolvedValue('hashed_password');
-      mockPrisma.user.create.mockResolvedValue({ id: 1, name: 'Jan', is_Admin: false });
+      mockPrisma.user.create.mockResolvedValue({
+        id: 1,
+        name: 'Jan',
+        is_Admin: false,
+      });
       (jwt.sign as jest.Mock).mockReturnValue('fake-token');
 
       const result = await service.register(dto);
@@ -69,7 +72,10 @@ describe('AuthService', () => {
     });
 
     it('powinno rzucić ConflictException gdy email jest zajęty', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 5, mail: 'test@example.com' });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 5,
+        mail: 'test@example.com',
+      });
 
       await expect(service.register(dto)).rejects.toThrow(ConflictException);
     });
@@ -77,13 +83,19 @@ describe('AuthService', () => {
     it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd przy sprawdzeniu emaila', async () => {
       mockPrisma.user.findUnique.mockRejectedValue(new Error('DB error'));
 
-      await expect(service.register(dto)).rejects.toThrow(InternalServerErrorException);
+      await expect(service.register(dto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
 
     it('powinno hashować hasło przed zapisem', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
       (bcrypt.hash as jest.Mock).mockResolvedValue('hashed_password');
-      mockPrisma.user.create.mockResolvedValue({ id: 1, name: 'Jan', is_Admin: false });
+      mockPrisma.user.create.mockResolvedValue({
+        id: 1,
+        name: 'Jan',
+        is_Admin: false,
+      });
       (jwt.sign as jest.Mock).mockReturnValue('fake-token');
 
       await service.register(dto);
@@ -140,7 +152,11 @@ describe('AuthService', () => {
   // ──────────────────────────────────────────────
   describe('removeUser', () => {
     it('powinno oznaczyć użytkownika jako usuniętego', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, name: 'Jan', is_Removed: false });
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Jan',
+        is_Removed: false,
+      });
       mockPrisma.user.update.mockResolvedValue({ id: 1, is_Removed: true });
 
       const result = await service.removeUser(1);
@@ -180,7 +196,9 @@ describe('AuthService', () => {
     it('powinno rzucić NotFoundException gdy użytkownik nie istnieje', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
 
-      await expect(service.verifyPassword(999, 'haslo')).rejects.toThrow(NotFoundException);
+      await expect(service.verifyPassword(999, 'haslo')).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -231,4 +231,13 @@ export class AuthService {
 
     return isPasswordValid;
   }
+
+async hardDeleteUser(userId: number) {
+  const user = await this.prisma.user.findUnique({ where: { id: userId } });
+  if (!user) throw new NotFoundException('Użytkownik nie został znaleziony');
+
+  await this.prisma.loan.deleteMany({ where: { user_id: userId } });
+
+  return this.prisma.user.delete({ where: { id: userId } });
+}
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -232,12 +232,12 @@ export class AuthService {
     return isPasswordValid;
   }
 
-async hardDeleteUser(userId: number) {
-  const user = await this.prisma.user.findUnique({ where: { id: userId } });
-  if (!user) throw new NotFoundException('Użytkownik nie został znaleziony');
+  async hardDeleteUser(userId: number) {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('Użytkownik nie został znaleziony');
 
-  await this.prisma.loan.deleteMany({ where: { user_id: userId } });
+    await this.prisma.loan.deleteMany({ where: { user_id: userId } });
 
-  return this.prisma.user.delete({ where: { id: userId } });
-}
+    return this.prisma.user.delete({ where: { id: userId } });
+  }
 }

--- a/backend/src/book/book.controller.ts
+++ b/backend/src/book/book.controller.ts
@@ -3,6 +3,7 @@ import {
   Get,
   Post,
   Patch,
+  Delete,
   Query,
   Param,
   Body,
@@ -127,4 +128,18 @@ export class BookController {
     }
     return this.bookService.updateBook(parseInt(id), dto);
   }
+
+@Delete('delete/:id')
+@HttpCode(HttpStatus.OK)
+@ApiOperation({
+  summary: 'Trwałe usunięcie książki',
+  description: 'Tylko administrator. Kaskadowo usuwa kopie i wypożyczenia.',
+})
+async hardDeleteBook(@Param('id') id: string, @Req() req: Request) {
+  const payload = await this.authService.verifyToken(req);
+  if (!payload.is_Admin) {
+    throw new ForbiddenException('Tylko administrator może trwale usuwać książki');
+  }
+  return this.bookService.hardDeleteBook(parseInt(id));
+}
 }

--- a/backend/src/book/book.controller.ts
+++ b/backend/src/book/book.controller.ts
@@ -89,7 +89,6 @@ export class BookController {
     return this.bookService.getBook(parseInt(id));
   }
 
-
   @Patch('update/:id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
@@ -104,15 +103,14 @@ export class BookController {
         cover: 'https://example.com/cover.jpg',
         publisher_name: 'SuperNowa',
         ISBN: '9788375352458',
-        authors: [
-          { author_name: 'Artur', author_lastname: 'Nowak' }
-        ],
+        authors: [{ author_name: 'Artur', author_lastname: 'Nowak' }],
       },
     },
   })
   async updateBook(
     @Param('id') id: string,
-    @Body() dto: {
+    @Body()
+    dto: {
       title?: string;
       year?: number;
       cover?: string;
@@ -124,22 +122,26 @@ export class BookController {
   ) {
     const payload = await this.authService.verifyToken(req);
     if (!payload.is_Admin) {
-      throw new ForbiddenException('Tylko administrator może modyfikować książki');
+      throw new ForbiddenException(
+        'Tylko administrator może modyfikować książki',
+      );
     }
     return this.bookService.updateBook(parseInt(id), dto);
   }
 
-@Delete('delete/:id')
-@HttpCode(HttpStatus.OK)
-@ApiOperation({
-  summary: 'Trwałe usunięcie książki',
-  description: 'Tylko administrator. Kaskadowo usuwa kopie i wypożyczenia.',
-})
-async hardDeleteBook(@Param('id') id: string, @Req() req: Request) {
-  const payload = await this.authService.verifyToken(req);
-  if (!payload.is_Admin) {
-    throw new ForbiddenException('Tylko administrator może trwale usuwać książki');
+  @Delete('delete/:id')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Trwałe usunięcie książki',
+    description: 'Tylko administrator. Kaskadowo usuwa kopie i wypożyczenia.',
+  })
+  async hardDeleteBook(@Param('id') id: string, @Req() req: Request) {
+    const payload = await this.authService.verifyToken(req);
+    if (!payload.is_Admin) {
+      throw new ForbiddenException(
+        'Tylko administrator może trwale usuwać książki',
+      );
+    }
+    return this.bookService.hardDeleteBook(parseInt(id));
   }
-  return this.bookService.hardDeleteBook(parseInt(id));
-}
 }

--- a/backend/src/book/book.service.spec.ts
+++ b/backend/src/book/book.service.spec.ts
@@ -62,9 +62,19 @@ describe('BookService', () => {
 
     it('powinno dodać książkę jeśli tytuł i ISBN są unikalne', async () => {
       mockPrisma.book.findFirst.mockResolvedValue(null); // brak duplikatu
-      mockPrisma.author.findFirst.mockResolvedValue({ id_author: 1, author_name: 'Andrzej', author_lastname: 'Sapkowski' });
-      mockPrisma.publisher.findFirst.mockResolvedValue({ id_publisher: 1, publisher_name: 'SuperNOWA' });
-      mockPrisma.book.create.mockResolvedValue({ id_book: 1, title: 'Wiedźmin' });
+      mockPrisma.author.findFirst.mockResolvedValue({
+        id_author: 1,
+        author_name: 'Andrzej',
+        author_lastname: 'Sapkowski',
+      });
+      mockPrisma.publisher.findFirst.mockResolvedValue({
+        id_publisher: 1,
+        publisher_name: 'SuperNOWA',
+      });
+      mockPrisma.book.create.mockResolvedValue({
+        id_book: 1,
+        title: 'Wiedźmin',
+      });
 
       const result = await service.addBook(dto);
 
@@ -73,7 +83,10 @@ describe('BookService', () => {
     });
 
     it('powinno rzucić ConflictException jeśli książka już istnieje', async () => {
-      mockPrisma.book.findFirst.mockResolvedValue({ id_book: 5, title: 'Wiedźmin' });
+      mockPrisma.book.findFirst.mockResolvedValue({
+        id_book: 5,
+        title: 'Wiedźmin',
+      });
 
       await expect(service.addBook(dto)).rejects.toThrow(ConflictException);
     });
@@ -82,13 +95,17 @@ describe('BookService', () => {
       mockPrisma.book.findFirst.mockResolvedValue(null);
       const badDto = { ...dto, ISBN: '123' }; // za krótki ISBN
 
-      await expect(service.addBook(badDto)).rejects.toThrow(BadRequestException);
+      await expect(service.addBook(badDto)).rejects.toThrow(
+        BadRequestException,
+      );
     });
 
     it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd', async () => {
       mockPrisma.book.findFirst.mockRejectedValue(new Error('DB error'));
 
-      await expect(service.addBook(dto)).rejects.toThrow(InternalServerErrorException);
+      await expect(service.addBook(dto)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 
@@ -99,7 +116,14 @@ describe('BookService', () => {
     it('powinno zwrócić paginowaną listę książek', async () => {
       mockPrisma.book.count.mockResolvedValue(25);
       mockPrisma.book.findMany.mockResolvedValue([
-        { id_book: 1, title: 'Wiedźmin', year: 1990, ISBN: '1234567890123', cover: null, authors: [] },
+        {
+          id_book: 1,
+          title: 'Wiedźmin',
+          year: 1990,
+          ISBN: '1234567890123',
+          cover: null,
+          authors: [],
+        },
       ]);
 
       const result = await service.searchBooks(1, 10);
@@ -130,7 +154,9 @@ describe('BookService', () => {
     it('powinno rzucić InternalServerErrorException gdy count się nie powiedzie', async () => {
       mockPrisma.book.count.mockRejectedValue(new Error('DB error'));
 
-      await expect(service.searchBooks(1, 10)).rejects.toThrow(InternalServerErrorException);
+      await expect(service.searchBooks(1, 10)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 
@@ -176,7 +202,11 @@ describe('BookService', () => {
   // ──────────────────────────────────────────────
   describe('getOrAddAuthor', () => {
     it('powinno zwrócić istniejącego autora', async () => {
-      const existingAuthor = { id_author: 1, author_name: 'Andrzej', author_lastname: 'Sapkowski' };
+      const existingAuthor = {
+        id_author: 1,
+        author_name: 'Andrzej',
+        author_lastname: 'Sapkowski',
+      };
       mockPrisma.author.findFirst.mockResolvedValue(existingAuthor);
 
       const result = await service.getOrAddAuthor('Andrzej', 'Sapkowski');
@@ -187,7 +217,11 @@ describe('BookService', () => {
 
     it('powinno stworzyć nowego autora gdy nie istnieje', async () => {
       mockPrisma.author.findFirst.mockResolvedValue(null);
-      mockPrisma.author.create.mockResolvedValue({ id_author: 2, author_name: 'Nowy', author_lastname: 'Autor' });
+      mockPrisma.author.create.mockResolvedValue({
+        id_author: 2,
+        author_name: 'Nowy',
+        author_lastname: 'Autor',
+      });
 
       const result = await service.getOrAddAuthor('Nowy', 'Autor');
 

--- a/backend/src/book/book.service.ts
+++ b/backend/src/book/book.service.ts
@@ -341,4 +341,15 @@ async updateBook(bookId: number, dto: {
     })
     .catch(() => { throw new InternalServerErrorException('Nie udało się zaktualizować książki'); });
 }
+  async hardDeleteBook(bookId: number) {
+  await this.findBookOrThrow(bookId);
+
+  await this.prisma.loan.deleteMany({
+    where: { copy: { book_id: bookId } },
+  });
+
+  await this.prisma.copy.deleteMany({ where: { book_id: bookId } });
+
+  return this.prisma.book.delete({ where: { id_book: bookId } });
+}
 }

--- a/backend/src/book/book.service.ts
+++ b/backend/src/book/book.service.ts
@@ -267,89 +267,123 @@ export class BookService {
     throw new InternalServerErrorException('Nie udało się dodać wydawnictwa');
   }
 
-async updateBook(bookId: number, dto: {
-  title?: string;
-  year?: number;
-  cover?: string;
-  publisher_name?: string;
-  ISBN?: string;
-  authors?: { author_name: string; author_lastname: string }[];
-}) {
-  await this.findBookOrThrow(bookId);
+  async updateBook(
+    bookId: number,
+    dto: {
+      title?: string;
+      year?: number;
+      cover?: string;
+      publisher_name?: string;
+      ISBN?: string;
+      authors?: { author_name: string; author_lastname: string }[];
+    },
+  ) {
+    await this.findBookOrThrow(bookId);
 
-  if (dto.ISBN && dto.ISBN.length !== 13) {
-    throw new BadRequestException('ISBN musi mieć dokładnie 13 znaków');
-  }
+    if (dto.ISBN && dto.ISBN.length !== 13) {
+      throw new BadRequestException('ISBN musi mieć dokładnie 13 znaków');
+    }
 
-  const currentYear = new Date().getFullYear();
-  if (dto.year && (dto.year < 1900 || dto.year > currentYear + 3)) {
-    throw new BadRequestException(`Rok publikacji musi być między 1900 a ${currentYear + 3}`);
-  }
+    const currentYear = new Date().getFullYear();
+    if (dto.year && (dto.year < 1900 || dto.year > currentYear + 3)) {
+      throw new BadRequestException(
+        `Rok publikacji musi być między 1900 a ${currentYear + 3}`,
+      );
+    }
 
-  if (dto.title || dto.ISBN) {
-    const existing = await this.prisma.book
-      .findFirst({
-        where: {
-          AND: [
-            { id_book: { not: bookId } },
-            {
-              OR: [
-                ...(dto.title ? [{ title: { equals: dto.title, mode: 'insensitive' as const } }] : []),
-                ...(dto.ISBN  ? [{ ISBN: dto.ISBN }] : []),
-              ],
+    if (dto.title || dto.ISBN) {
+      const existing = await this.prisma.book
+        .findFirst({
+          where: {
+            AND: [
+              { id_book: { not: bookId } },
+              {
+                OR: [
+                  ...(dto.title
+                    ? [
+                        {
+                          title: {
+                            equals: dto.title,
+                            mode: 'insensitive' as const,
+                          },
+                        },
+                      ]
+                    : []),
+                  ...(dto.ISBN ? [{ ISBN: dto.ISBN }] : []),
+                ],
+              },
+            ],
+          },
+        })
+        .catch(() => {
+          throw new InternalServerErrorException('Błąd bazy danych');
+        });
+
+      if (existing) {
+        throw new ConflictException(
+          'Książka o takim tytule lub ISBN już istnieje',
+        );
+      }
+    }
+
+    const publisher = dto.publisher_name
+      ? await this.getOrAddPublisher(dto.publisher_name)
+      : undefined;
+
+    const authors = dto.authors
+      ? await Promise.all(
+          dto.authors.map((a) =>
+            this.getOrAddAuthor(a.author_name, a.author_lastname),
+          ),
+        )
+      : undefined;
+
+    return this.prisma.book
+      .update({
+        where: { id_book: bookId },
+        data: {
+          ...(dto.title && { title: dto.title }),
+          ...(dto.year && { year: dto.year }),
+          ...(dto.cover && { cover: dto.cover }),
+          ...(dto.ISBN && { ISBN: dto.ISBN }),
+          ...(publisher && {
+            publisher: { connect: { id_publisher: publisher.id_publisher } },
+          }),
+          ...(authors && {
+            authors: { set: authors.map((a) => ({ id_author: a.id_author })) },
+          }),
+        },
+        select: {
+          id_book: true,
+          title: true,
+          year: true,
+          cover: true,
+          ISBN: true,
+          publisher: { select: { id_publisher: true, publisher_name: true } },
+          authors: {
+            select: {
+              id_author: true,
+              author_name: true,
+              author_lastname: true,
             },
-          ],
+          },
         },
       })
-      .catch(() => { throw new InternalServerErrorException('Błąd bazy danych'); });
-
-    if (existing) {
-      throw new ConflictException('Książka o takim tytule lub ISBN już istnieje');
-    }
+      .catch(() => {
+        throw new InternalServerErrorException(
+          'Nie udało się zaktualizować książki',
+        );
+      });
   }
-
-  const publisher = dto.publisher_name
-    ? await this.getOrAddPublisher(dto.publisher_name)
-    : undefined;
-
-  const authors = dto.authors
-    ? await Promise.all(
-        dto.authors.map((a) => this.getOrAddAuthor(a.author_name, a.author_lastname))
-      )
-    : undefined;
-
-  return this.prisma.book
-    .update({
-      where: { id_book: bookId },
-      data: {
-        ...(dto.title       && { title: dto.title }),
-        ...(dto.year        && { year: dto.year }),
-        ...(dto.cover       && { cover: dto.cover }),
-        ...(dto.ISBN        && { ISBN: dto.ISBN }),
-        ...(publisher       && { publisher: { connect: { id_publisher: publisher.id_publisher } } }),
-        ...(authors         && { authors: { set: authors.map((a) => ({ id_author: a.id_author })) } }),
-      },
-      select: {
-        id_book: true,
-        title: true,
-        year: true,
-        cover: true,
-        ISBN: true,
-        publisher: { select: { id_publisher: true, publisher_name: true } },
-        authors: { select: { id_author: true, author_name: true, author_lastname: true } },
-      },
-    })
-    .catch(() => { throw new InternalServerErrorException('Nie udało się zaktualizować książki'); });
-}
   async hardDeleteBook(bookId: number) {
-  await this.findBookOrThrow(bookId);
+    await this.findBookOrThrow(bookId);
 
-  await this.prisma.loan.deleteMany({
-    where: { copy: { book_id: bookId } },
-  });
+    await this.prisma.loan.deleteMany({
+      where: { copy: { book_id: bookId } },
+    });
 
-  await this.prisma.copy.deleteMany({ where: { book_id: bookId } });
+    await this.prisma.copy.deleteMany({ where: { book_id: bookId } });
 
-  return this.prisma.book.delete({ where: { id_book: bookId } });
-}
+    return this.prisma.book.delete({ where: { id_book: bookId } });
+  }
 }

--- a/backend/src/copy/copy.service.spec.ts
+++ b/backend/src/copy/copy.service.spec.ts
@@ -1,11 +1,7 @@
-import {
-  NotFoundException,
-  BadRequestException
-} from '@nestjs/common';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CopyService } from './copy.service';
 import { PrismaService } from '../prisma.service';
-
 
 const mockPrisma = {
   copy: {
@@ -21,7 +17,7 @@ const mockPrisma = {
   },
   book: {
     findUnique: jest.fn(),
-  }
+  },
 };
 
 describe('CopyService', () => {
@@ -29,7 +25,6 @@ describe('CopyService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -40,240 +35,228 @@ describe('CopyService', () => {
 
     service = module.get<CopyService>(CopyService);
   });
- 
-    
-    // getCopyIsLoan
-    describe('getCopyIsLoan', () => {
-      it('Sprawdzenie dostępności dostępnej kopii', async () => {
-        mockPrisma.loan.count.mockResolvedValue(4);
-  
-        const result = await service.getCopyIsLoan(1);
 
-        expect(result).toBe(true);
+  // getCopyIsLoan
+  describe('getCopyIsLoan', () => {
+    it('Sprawdzenie dostępności dostępnej kopii', async () => {
+      mockPrisma.loan.count.mockResolvedValue(4);
 
-      });
+      const result = await service.getCopyIsLoan(1);
 
-      it('Sprawdzenie dostępności niedostępnej kopii', async () => {
-        mockPrisma.loan.count.mockResolvedValue(0);
-  
-        const result = await service.getCopyIsLoan(1);
-
-        expect(result).toBe(false);
-      });
-
-      
+      expect(result).toBe(true);
     });
 
-    // getCopy
-    describe('getCopy', () => {
-      it('Pobranie danych kopii', async () => {
-        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
-                                                    book_id: 1,
-                                                    is_actual: true,
-                                                    is_loan: false,
-                                                    });  
-        mockPrisma.loan.count.mockResolvedValue(0);
-  
-        const result = await service.getCopy(1);
-        if(result !== null){
-            expect(result.id_copy).toBe(1);
-            expect(result.book_id).toBe(1);
-            expect(result.is_actual).toBe(true);
-            expect(result.is_loan).toBe(false);
-        }
-      });
+    it('Sprawdzenie dostępności niedostępnej kopii', async () => {
+      mockPrisma.loan.count.mockResolvedValue(0);
 
-      it('Nie można pobrać danych nieistniejącej kopii', async () => {
-        mockPrisma.copy.findUnique.mockResolvedValue(null);  
-  
-        const result = await service.getCopy(1);
-        
-        expect(result).toBe(null);
-      });
-      
+      const result = await service.getCopyIsLoan(1);
+
+      expect(result).toBe(false);
     });
-  
-    // getBookCopies
-    describe('getBookCopies', () => {
-      const lista = [{id_copy: 8,
-                    book_id: 1,
-                    is_actual: true,
-                    is_loan: true
-                    },
-                    {
-                    id_copy: 13,
-                    book_id: 1,
-                    is_actual: true,
-                    is_loan: true
-                    },
-                    {
-                    id_copy: 25,
-                    book_id: 1,
-                    is_actual: true,
-                    is_loan: true
-                    },
-                    {
-                    id_copy: 35,
-                    book_id: 1,
-                    is_actual: true,
-                    is_loan: true
-                    },];
+  });
 
-      it('Pobranie danych o kopiach książki', async () => {
-        mockPrisma.copy.findMany.mockResolvedValue(lista);  
-        mockPrisma.loan.count.mockResolvedValue(2);
-        mockPrisma.copy.count.mockResolvedValue(4);
-  
-        const result = await service.getBookCopies(1, 1, 2);
-        expect(result.data).toHaveLength(4);
-        expect(result.data).toEqual(lista);
-
-        expect(result.meta.page).toBe(1);
-        expect(result.meta.limit).toBe(2);
-        expect(result.meta.total).toBe(4);
-        expect(result.meta.totalPages).toBe(2);
-
+  // getCopy
+  describe('getCopy', () => {
+    it('Pobranie danych kopii', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue({
+        id_copy: 1,
+        book_id: 1,
+        is_actual: true,
+        is_loan: false,
       });
-      
-      it('Pobranie pustej listy przez podanie złej strony', async () => {
-        mockPrisma.copy.findMany.mockResolvedValue([]);  
-        mockPrisma.loan.count.mockResolvedValue(0);
-        mockPrisma.copy.count.mockResolvedValue(0);
-  
-        const result = await service.getBookCopies(1, 3, 2);
-        expect(result.data).toHaveLength(0);
-        expect(result.data).toEqual([]);
+      mockPrisma.loan.count.mockResolvedValue(0);
 
-        expect(result.meta.page).toBe(3);
-        expect(result.meta.limit).toBe(2);
-        expect(result.meta.total).toBe(0);
-        expect(result.meta.totalPages).toBe(0);
-
-      });
-
-      it('Pobranie danych o kopiach książki, pomimo podania ujemnej strony', async () => {
-        mockPrisma.copy.findMany.mockResolvedValue(lista);  
-        mockPrisma.loan.count.mockResolvedValue(2);
-        mockPrisma.copy.count.mockResolvedValue(4);
-  
-        const result = await service.getBookCopies(1, -10, 2);
-        expect(result.data).toHaveLength(4);
-        expect(result.data).toEqual(lista);
-        
-        expect(result.meta.page).toBe(1);
-        expect(result.meta.limit).toBe(2);
-        expect(result.meta.total).toBe(4);
-        expect(result.meta.totalPages).toBe(2);
-
-      });
-
-      it('Pobranie danych o kopiach książki, pomimo podania ujemnego limitu', async () => {
-        mockPrisma.copy.findMany.mockResolvedValue(lista);  
-        mockPrisma.loan.count.mockResolvedValue(2);
-        mockPrisma.copy.count.mockResolvedValue(4);
-  
-        const result = await service.getBookCopies(1, 1, -10);
-        expect(result.data).toHaveLength(4);
-        expect(result.data).toEqual(lista);
-        
-        expect(result.meta.page).toBe(1);
-        expect(result.meta.limit).toBe(1);
-        expect(result.meta.total).toBe(4);
-        expect(result.meta.totalPages).toBe(4);
-
-      });
-
-      it('Pobranie pustej listy o kopiach książki przez podanie błędnego id', async () => {
-        mockPrisma.copy.findMany.mockResolvedValue([]);  
-        mockPrisma.loan.count.mockResolvedValue(0);
-        mockPrisma.copy.count.mockResolvedValue(0);
-  
-        const result = await service.getBookCopies(99, 1, 1);
-        expect(result.data).toHaveLength(0);
-        expect(result.data).toEqual([]);
-        
-        expect(result.meta.page).toBe(1);
-        expect(result.meta.limit).toBe(1);
-        expect(result.meta.total).toBe(0);
-        expect(result.meta.totalPages).toBe(0);
-
-      });
-
-    });
-
-
-    // addCopy
-    describe('addCopy', () => {
-      it('Utworzenie nowej kopii', async () => {
-        mockPrisma.copy.create.mockResolvedValue({ id_copy: 1, 
-                                                    book_id:1,
-                                                    is_actual: true,
-                                                    is_loan: false,
-                                                    });
-        mockPrisma.loan.count.mockResolvedValue(0);
-        mockPrisma.book.findUnique.mockResolvedValue({id_book:1})
-  
-  
-        const result = await service.addCopy(1);
-      
+      const result = await service.getCopy(1);
+      if (result !== null) {
         expect(result.id_copy).toBe(1);
         expect(result.book_id).toBe(1);
         expect(result.is_actual).toBe(true);
         expect(result.is_loan).toBe(false);
-      });
-      
-      it('Nie można stworzyć kopii nieistniejącej książki', async () => {
-        mockPrisma.book.findUnique.mockResolvedValue(null);  
-        await expect(service.addCopy(1)).rejects.toThrow(NotFoundException);
-      
-      });
-
+      }
     });
 
-    // removeCopy
-    describe('removeCopy', () => {
-      it('Kopia książki została usunięta', async () => {
-        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
-                                                    book_id:1,
-                                                    is_actual: true,
-                                                    });
-  
-        mockPrisma.copy.update.mockResolvedValue({ id_copy: 1, 
-                                              is_actual: false});
-        mockPrisma.loan.count.mockResolvedValue(0);
-  
-        const result = await service.removeCopy(1);
-      
-        expect(result.id_copy).toBe(1);
-        expect(result.is_actual).toBe(false);
-      });
-      
-      it('Kopia nie może być usunięta, ponieważ jest aktualnie wypożyczona', async () => {
-        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
-                                                    book_id:1,
-                                                    is_actual: true,
-                                                   });
-        mockPrisma.loan.count.mockResolvedValue(3);
-  
-        await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
-      });
-  
-      it('Kopia nie może być usunięta, ponieważ została usunięta już wcześniej', async () => {
-        mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, 
-                                                    book_id:1,
-                                                    is_actual: false,
-                                                   });
-        mockPrisma.loan.count.mockResolvedValue(0);
-  
-        await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
-      });
+    it('Nie można pobrać danych nieistniejącej kopii', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue(null);
 
-      it('Nie odnaleziono kopii', async () => {
-        mockPrisma.copy.findUnique.mockResolvedValue(null);
-  
-        await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
-      });
+      const result = await service.getCopy(1);
+
+      expect(result).toBe(null);
+    });
+  });
+
+  // getBookCopies
+  describe('getBookCopies', () => {
+    const lista = [
+      { id_copy: 8, book_id: 1, is_actual: true, is_loan: true },
+      {
+        id_copy: 13,
+        book_id: 1,
+        is_actual: true,
+        is_loan: true,
+      },
+      {
+        id_copy: 25,
+        book_id: 1,
+        is_actual: true,
+        is_loan: true,
+      },
+      {
+        id_copy: 35,
+        book_id: 1,
+        is_actual: true,
+        is_loan: true,
+      },
+    ];
+
+    it('Pobranie danych o kopiach książki', async () => {
+      mockPrisma.copy.findMany.mockResolvedValue(lista);
+      mockPrisma.loan.count.mockResolvedValue(2);
+      mockPrisma.copy.count.mockResolvedValue(4);
+
+      const result = await service.getBookCopies(1, 1, 2);
+      expect(result.data).toHaveLength(4);
+      expect(result.data).toEqual(lista);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(4);
+      expect(result.meta.totalPages).toBe(2);
     });
 
+    it('Pobranie pustej listy przez podanie złej strony', async () => {
+      mockPrisma.copy.findMany.mockResolvedValue([]);
+      mockPrisma.loan.count.mockResolvedValue(0);
+      mockPrisma.copy.count.mockResolvedValue(0);
 
-});   
+      const result = await service.getBookCopies(1, 3, 2);
+      expect(result.data).toHaveLength(0);
+      expect(result.data).toEqual([]);
+
+      expect(result.meta.page).toBe(3);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+
+    it('Pobranie danych o kopiach książki, pomimo podania ujemnej strony', async () => {
+      mockPrisma.copy.findMany.mockResolvedValue(lista);
+      mockPrisma.loan.count.mockResolvedValue(2);
+      mockPrisma.copy.count.mockResolvedValue(4);
+
+      const result = await service.getBookCopies(1, -10, 2);
+      expect(result.data).toHaveLength(4);
+      expect(result.data).toEqual(lista);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.total).toBe(4);
+      expect(result.meta.totalPages).toBe(2);
+    });
+
+    it('Pobranie danych o kopiach książki, pomimo podania ujemnego limitu', async () => {
+      mockPrisma.copy.findMany.mockResolvedValue(lista);
+      mockPrisma.loan.count.mockResolvedValue(2);
+      mockPrisma.copy.count.mockResolvedValue(4);
+
+      const result = await service.getBookCopies(1, 1, -10);
+      expect(result.data).toHaveLength(4);
+      expect(result.data).toEqual(lista);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(1);
+      expect(result.meta.total).toBe(4);
+      expect(result.meta.totalPages).toBe(4);
+    });
+
+    it('Pobranie pustej listy o kopiach książki przez podanie błędnego id', async () => {
+      mockPrisma.copy.findMany.mockResolvedValue([]);
+      mockPrisma.loan.count.mockResolvedValue(0);
+      mockPrisma.copy.count.mockResolvedValue(0);
+
+      const result = await service.getBookCopies(99, 1, 1);
+      expect(result.data).toHaveLength(0);
+      expect(result.data).toEqual([]);
+
+      expect(result.meta.page).toBe(1);
+      expect(result.meta.limit).toBe(1);
+      expect(result.meta.total).toBe(0);
+      expect(result.meta.totalPages).toBe(0);
+    });
+  });
+
+  // addCopy
+  describe('addCopy', () => {
+    it('Utworzenie nowej kopii', async () => {
+      mockPrisma.copy.create.mockResolvedValue({
+        id_copy: 1,
+        book_id: 1,
+        is_actual: true,
+        is_loan: false,
+      });
+      mockPrisma.loan.count.mockResolvedValue(0);
+      mockPrisma.book.findUnique.mockResolvedValue({ id_book: 1 });
+
+      const result = await service.addCopy(1);
+
+      expect(result.id_copy).toBe(1);
+      expect(result.book_id).toBe(1);
+      expect(result.is_actual).toBe(true);
+      expect(result.is_loan).toBe(false);
+    });
+
+    it('Nie można stworzyć kopii nieistniejącej książki', async () => {
+      mockPrisma.book.findUnique.mockResolvedValue(null);
+      await expect(service.addCopy(1)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // removeCopy
+  describe('removeCopy', () => {
+    it('Kopia książki została usunięta', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue({
+        id_copy: 1,
+        book_id: 1,
+        is_actual: true,
+      });
+
+      mockPrisma.copy.update.mockResolvedValue({
+        id_copy: 1,
+        is_actual: false,
+      });
+      mockPrisma.loan.count.mockResolvedValue(0);
+
+      const result = await service.removeCopy(1);
+
+      expect(result.id_copy).toBe(1);
+      expect(result.is_actual).toBe(false);
+    });
+
+    it('Kopia nie może być usunięta, ponieważ jest aktualnie wypożyczona', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue({
+        id_copy: 1,
+        book_id: 1,
+        is_actual: true,
+      });
+      mockPrisma.loan.count.mockResolvedValue(3);
+
+      await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
+    });
+
+    it('Kopia nie może być usunięta, ponieważ została usunięta już wcześniej', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue({
+        id_copy: 1,
+        book_id: 1,
+        is_actual: false,
+      });
+      mockPrisma.loan.count.mockResolvedValue(0);
+
+      await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
+    });
+
+    it('Nie odnaleziono kopii', async () => {
+      mockPrisma.copy.findUnique.mockResolvedValue(null);
+
+      await expect(service.removeCopy(1)).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/backend/src/copy/copy.service.ts
+++ b/backend/src/copy/copy.service.ts
@@ -1,4 +1,9 @@
-import { BadRequestException, NotFoundException, InternalServerErrorException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+  InternalServerErrorException,
+  Injectable,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
 
 @Injectable()
@@ -79,13 +84,13 @@ export class CopyService {
         select: {
           id_book: true,
         },
-      }).catch(() => {
+      })
+      .catch(() => {
         throw new InternalServerErrorException('Błąd bazy danych');
       });
 
     if (!book)
       throw new NotFoundException(`Książka o id ${id_book} nie istnieje`);
-
 
     const newCopy = await this.prisma.copy.create({
       data: {

--- a/backend/src/loan/loan.controller.ts
+++ b/backend/src/loan/loan.controller.ts
@@ -28,7 +28,8 @@ export class LoanController {
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     summary: 'Wypożyczenie kopii książki',
-    description: 'Wypożycza wybraną kopię książki dla zalogowanego użytkownika.',
+    description:
+      'Wypożycza wybraną kopię książki dla zalogowanego użytkownika.',
   })
   async loanBook(@Param('copy_id') copyIdParam: string, @Req() req: Request) {
     const payload = await this.authService.verifyToken(req);
@@ -39,7 +40,9 @@ export class LoanController {
 
     const copyId = Number(copyIdParam);
     if (!Number.isInteger(copyId) || copyId <= 0) {
-      throw new BadRequestException('copy_id musi być dodatnią liczbą całkowitą');
+      throw new BadRequestException(
+        'copy_id musi być dodatnią liczbą całkowitą',
+      );
     }
 
     return await this.loanService.loanBook(payload.id, copyId);
@@ -56,7 +59,9 @@ export class LoanController {
 
     const copyId = Number(copyIdParam);
     if (!Number.isInteger(copyId) || copyId <= 0) {
-      throw new BadRequestException('copy_id musi być dodatnią liczbą całkowitą');
+      throw new BadRequestException(
+        'copy_id musi być dodatnią liczbą całkowitą',
+      );
     }
 
     return await this.loanService.returnBook(payload.id, copyId);
@@ -66,7 +71,8 @@ export class LoanController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Historia wypożyczeń użytkownika',
-    description: 'Zwraca wszystkie wypożyczenia zalogowanego użytkownika, także zwrócone.',
+    description:
+      'Zwraca wszystkie wypożyczenia zalogowanego użytkownika, także zwrócone.',
   })
   @ApiQuery({
     name: 'page',
@@ -96,7 +102,8 @@ export class LoanController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Lista wypożyczeń użytkownika, które nie zostały jeszcze zwrócone',
-    description: 'Zwraca wszystkie aktywne wypożyczenia zalogowanego użytkownika.',
+    description:
+      'Zwraca wszystkie aktywne wypożyczenia zalogowanego użytkownika.',
   })
   @ApiQuery({
     name: 'page',
@@ -119,16 +126,19 @@ export class LoanController {
 
     const pageNum = page ? parseInt(page) : 1;
     const limitNum = limit ? parseInt(limit) : 10;
-    return await this.loanService.getUserActiveLoans(payload.id, pageNum, limitNum);
+    return await this.loanService.getUserActiveLoans(
+      payload.id,
+      pageNum,
+      limitNum,
+    );
   }
-
-
 
   @Get('loans/:user_id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Historia wypożyczeń wybranego użytkownika',
-    description: 'Tylko administrator może zobaczyć wypożyczenia dowolnego użytkownika.',
+    description:
+      'Tylko administrator może zobaczyć wypożyczenia dowolnego użytkownika.',
   })
   @ApiQuery({
     name: 'page',
@@ -151,12 +161,16 @@ export class LoanController {
     const payload = await this.authService.verifyToken(req);
 
     if (!payload.is_Admin) {
-      throw new ForbiddenException('Tylko administrator może przeglądać wypożyczenia innych użytkowników');
+      throw new ForbiddenException(
+        'Tylko administrator może przeglądać wypożyczenia innych użytkowników',
+      );
     }
 
     const userId = Number(userIdParam);
     if (!Number.isInteger(userId) || userId <= 0) {
-      throw new BadRequestException('user_id musi być dodatnią liczbą całkowitą');
+      throw new BadRequestException(
+        'user_id musi być dodatnią liczbą całkowitą',
+      );
     }
 
     const pageNum = page ? parseInt(page) : 1;

--- a/backend/src/loan/loan.service.spec.ts
+++ b/backend/src/loan/loan.service.spec.ts
@@ -41,9 +41,15 @@ describe('LoanService', () => {
   // ──────────────────────────────────────────────
   describe('loanBook', () => {
     it('powinno wypożyczyć dostępną kopię', async () => {
-      mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, is_actual: true });
+      mockPrisma.copy.findUnique.mockResolvedValue({
+        id_copy: 1,
+        is_actual: true,
+      });
       mockPrisma.loan.findFirst.mockResolvedValue(null); // brak aktywnego wypożyczenia
-      mockPrisma.loan.create.mockResolvedValue({ copy_id: 1, start_date: new Date() });
+      mockPrisma.loan.create.mockResolvedValue({
+        copy_id: 1,
+        start_date: new Date(),
+      });
 
       const result = await service.loanBook(42, 1);
 
@@ -54,18 +60,30 @@ describe('LoanService', () => {
     it('powinno rzucić NotFoundException gdy kopia nie istnieje', async () => {
       mockPrisma.copy.findUnique.mockResolvedValue(null);
 
-      await expect(service.loanBook(42, 999)).rejects.toThrow(NotFoundException);
+      await expect(service.loanBook(42, 999)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('powinno rzucić NotFoundException gdy kopia jest nieaktualna (usunięta)', async () => {
-      mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, is_actual: false });
+      mockPrisma.copy.findUnique.mockResolvedValue({
+        id_copy: 1,
+        is_actual: false,
+      });
 
       await expect(service.loanBook(42, 1)).rejects.toThrow(NotFoundException);
     });
 
     it('powinno rzucić ConflictException gdy kopia jest już wypożyczona', async () => {
-      mockPrisma.copy.findUnique.mockResolvedValue({ id_copy: 1, is_actual: true });
-      mockPrisma.loan.findFirst.mockResolvedValue({ id_loan: 99, copy_id: 1, return_date: null }); // aktywne wypożyczenie
+      mockPrisma.copy.findUnique.mockResolvedValue({
+        id_copy: 1,
+        is_actual: true,
+      });
+      mockPrisma.loan.findFirst.mockResolvedValue({
+        id_loan: 99,
+        copy_id: 1,
+        return_date: null,
+      }); // aktywne wypożyczenie
 
       await expect(service.loanBook(42, 1)).rejects.toThrow(ConflictException);
     });
@@ -73,7 +91,9 @@ describe('LoanService', () => {
     it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd przy szukaniu kopii', async () => {
       mockPrisma.copy.findUnique.mockRejectedValue(new Error('DB error'));
 
-      await expect(service.loanBook(42, 1)).rejects.toThrow(InternalServerErrorException);
+      await expect(service.loanBook(42, 1)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 
@@ -83,8 +103,16 @@ describe('LoanService', () => {
   describe('returnBook', () => {
     it('powinno zwrócić książkę gdy istnieje aktywne wypożyczenie', async () => {
       const returnDate = new Date();
-      mockPrisma.loan.findFirst.mockResolvedValue({ id_loan: 10, user_id: 42, copy_id: 1, return_date: null });
-      mockPrisma.loan.update.mockResolvedValue({ copy_id: 1, return_date: returnDate });
+      mockPrisma.loan.findFirst.mockResolvedValue({
+        id_loan: 10,
+        user_id: 42,
+        copy_id: 1,
+        return_date: null,
+      });
+      mockPrisma.loan.update.mockResolvedValue({
+        copy_id: 1,
+        return_date: returnDate,
+      });
 
       const result = await service.returnBook(42, 1);
 
@@ -97,14 +125,23 @@ describe('LoanService', () => {
     it('powinno rzucić NotFoundException gdy brak aktywnego wypożyczenia', async () => {
       mockPrisma.loan.findFirst.mockResolvedValue(null);
 
-      await expect(service.returnBook(42, 1)).rejects.toThrow(NotFoundException);
+      await expect(service.returnBook(42, 1)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('powinno rzucić InternalServerErrorException gdy update się nie powiedzie', async () => {
-      mockPrisma.loan.findFirst.mockResolvedValue({ id_loan: 10, user_id: 42, copy_id: 1, return_date: null });
+      mockPrisma.loan.findFirst.mockResolvedValue({
+        id_loan: 10,
+        user_id: 42,
+        copy_id: 1,
+        return_date: null,
+      });
       mockPrisma.loan.update.mockRejectedValue(new Error('DB error'));
 
-      await expect(service.returnBook(42, 1)).rejects.toThrow(InternalServerErrorException);
+      await expect(service.returnBook(42, 1)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
   });
 
@@ -119,7 +156,15 @@ describe('LoanService', () => {
           copy_id: 1,
           start_date: new Date('2024-01-01'),
           return_date: new Date('2024-01-15'),
-          copy: { id_copy: 1, book: { id_book: 1, title: 'Wiedźmin', cover: null, ISBN: '1234567890123' } },
+          copy: {
+            id_copy: 1,
+            book: {
+              id_book: 1,
+              title: 'Wiedźmin',
+              cover: null,
+              ISBN: '1234567890123',
+            },
+          },
         },
       ];
       mockPrisma.loan.findMany.mockResolvedValue(loans);
@@ -129,7 +174,12 @@ describe('LoanService', () => {
 
       expect(result.data).toHaveLength(1);
       expect(result.data[0].copy.book.title).toBe('Wiedźmin');
-      expect(result.meta).toEqual({ page: 1, limit: 10, total: 1, totalPages: 1 });
+      expect(result.meta).toEqual({
+        page: 1,
+        limit: 10,
+        total: 1,
+        totalPages: 1,
+      });
     });
 
     it('powinno zwrócić pustą tablicę gdy użytkownik nie ma wypożyczeń', async () => {
@@ -147,7 +197,9 @@ describe('LoanService', () => {
     it('powinno rzucić InternalServerErrorException gdy baza zwróci błąd', async () => {
       mockPrisma.loan.findMany.mockRejectedValue(new Error('DB error'));
 
-      await expect(service.getUserLoans(42)).rejects.toThrow(InternalServerErrorException);
+      await expect(service.getUserLoans(42)).rejects.toThrow(
+        InternalServerErrorException,
+      );
     });
 
     it('powinno stosować paginację do historii wypożyczeń', async () => {

--- a/backend/src/loan/loan.service.ts
+++ b/backend/src/loan/loan.service.ts
@@ -21,7 +21,6 @@ export class LoanService {
   }
 
   async loanBook(userId: number, copyId: number) {
-
     const copy = await this.prisma.copy
       .findUnique({
         where: { id_copy: copyId },
@@ -57,12 +56,13 @@ export class LoanService {
         select: { copy_id: true, start_date: true },
       })
       .catch(() => {
-        throw new InternalServerErrorException('Nie udało się wypożyczyć książki');
+        throw new InternalServerErrorException(
+          'Nie udało się wypożyczyć książki',
+        );
       });
   }
 
   async returnBook(userId: number, copyId: number) {
-
     const activeLoan = await this.prisma.loan
       .findFirst({
         where: {
@@ -91,7 +91,10 @@ export class LoanService {
   }
 
   async getUserLoans(userId: number, page = 1, limit = 10) {
-    const { validPage, validLimit, skip } = this.normalizePagination(page, limit);
+    const { validPage, validLimit, skip } = this.normalizePagination(
+      page,
+      limit,
+    );
 
     const [loans, total] = await Promise.all([
       this.prisma.loan.findMany({
@@ -138,7 +141,10 @@ export class LoanService {
   }
 
   async getUserActiveLoans(userId: number, page: number, limit: number) {
-    const { validPage, validLimit, skip } = this.normalizePagination(page, limit);
+    const { validPage, validLimit, skip } = this.normalizePagination(
+      page,
+      limit,
+    );
 
     const [loans, total] = await Promise.all([
       this.prisma.loan.findMany({

--- a/backend/src/user/dto/updateUser.dto.ts
+++ b/backend/src/user/dto/updateUser.dto.ts
@@ -1,4 +1,10 @@
-import { IsString, IsNotEmpty, ValidateIf, MinLength, MaxLength } from 'class-validator';
+import {
+  IsString,
+  IsNotEmpty,
+  ValidateIf,
+  MinLength,
+  MaxLength,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateUserDto {

--- a/backend/src/user/user.service.spec.ts
+++ b/backend/src/user/user.service.spec.ts
@@ -1,7 +1,4 @@
-import {
-  NotFoundException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as bcrypt from 'bcrypt';
 import { UserService } from './user.service';
@@ -24,7 +21,6 @@ describe('UserService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
-    
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -39,17 +35,19 @@ describe('UserService', () => {
   // GetUser
   describe('getUser', () => {
     it('Zwrócono informacje o użytkowniku', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            mail: 'subiekt@sklep.pl',
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            is_Admin: false,
-                                            is_Banned: false,
-                                            is_Removed: false,
-                                            loans: [],});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        mail: 'subiekt@sklep.pl',
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        is_Admin: false,
+        is_Banned: false,
+        is_Removed: false,
+        loans: [],
+      });
 
       const result = await service.getUser(1);
-      
+
       expect(result.id).toBe(1);
       expect(result.mail).toBe('subiekt@sklep.pl');
       expect(result.name).toBe('Ignacy');
@@ -57,50 +55,53 @@ describe('UserService', () => {
       expect(result.is_Admin).toBe(false);
       expect(result.is_Banned).toBe(false);
       expect(result.is_Removed).toBe(false);
-      
     });
 
     it('Nie znaleziono użytkownika', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
 
-      await expect(service.getUser(1)).rejects.toThrow(NotFoundException);    
+      await expect(service.getUser(1)).rejects.toThrow(NotFoundException);
     });
-
-    
   });
-
 
   // searchUsers
   describe('searchUsers', () => {
-    const lista = [{ id: 1, 
-                     name: 'Ignacy', 
-                     lastname: "Rzecki", 
-                     mail: 'subiekt@sklep.pl',
-                     is_Admin: false,
-                     is_Banned: false,
-                     is_Removed: false,},
-                   { id: 2, 
-                     name: 'Stanisław', 
-                     lastname: "Wokulski", 
-                     mail: 'subiekt2@sklep.pl',
-                     is_Admin: false,
-                     is_Banned: false,
-                     is_Removed: false,},
-                   { id: 3, 
-                     name: 'Henryk', 
-                     lastname: "Szlangbaum", 
-                     mail: 'subiekt3@sklep.pl',
-                     is_Admin: false,
-                     is_Banned: false,
-                     is_Removed: false,}];
-
+    const lista = [
+      {
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        mail: 'subiekt@sklep.pl',
+        is_Admin: false,
+        is_Banned: false,
+        is_Removed: false,
+      },
+      {
+        id: 2,
+        name: 'Stanisław',
+        lastname: 'Wokulski',
+        mail: 'subiekt2@sklep.pl',
+        is_Admin: false,
+        is_Banned: false,
+        is_Removed: false,
+      },
+      {
+        id: 3,
+        name: 'Henryk',
+        lastname: 'Szlangbaum',
+        mail: 'subiekt3@sklep.pl',
+        is_Admin: false,
+        is_Banned: false,
+        is_Removed: false,
+      },
+    ];
 
     it('Uzyskanie listy użytkowników z paginacją', async () => {
-       mockPrisma.user.findMany.mockResolvedValue(lista);
-       mockPrisma.user.count.mockResolvedValue(3)
+      mockPrisma.user.findMany.mockResolvedValue(lista);
+      mockPrisma.user.count.mockResolvedValue(3);
 
-       const result = await service.searchUsers(1, 2);
-    
+      const result = await service.searchUsers(1, 2);
+
       expect(result.data).toHaveLength(3);
       expect(result.data).toBe(lista);
 
@@ -108,231 +109,241 @@ describe('UserService', () => {
       expect(result.meta.limit).toBe(2);
       expect(result.meta.total).toBe(3);
       expect(result.meta.totalPages).toBe(2);
-      
-
-     });
+    });
 
     it('Uzyskanie pustej listy przez źle podaną strone', async () => {
-       mockPrisma.user.findMany.mockResolvedValue([]);
-       mockPrisma.user.count.mockResolvedValue(3);
+      mockPrisma.user.findMany.mockResolvedValue([]);
+      mockPrisma.user.count.mockResolvedValue(3);
 
-       const result = await service.searchUsers(3, 2);
-    
+      const result = await service.searchUsers(3, 2);
+
       expect(result.data).toEqual([]);
 
       expect(result.meta.page).toBe(3);
       expect(result.meta.limit).toBe(2);
       expect(result.meta.total).toBe(3);
       expect(result.meta.totalPages).toBe(2);
-      
-
-     });
+    });
 
     it('Uzyskanie listy użytkowniku mimo podania ujemnej strony', async () => {
       mockPrisma.user.findMany.mockResolvedValue(lista);
       mockPrisma.user.count.mockResolvedValue(3);
 
       const result = await service.searchUsers(-1, 2);
-    
+
       expect(result.data).toBe(lista);
 
       expect(result.meta.page).toBe(1);
       expect(result.meta.limit).toBe(2);
       expect(result.meta.total).toBe(3);
       expect(result.meta.totalPages).toBe(2);
-      
-
-     });
+    });
 
     it('Uzyskanie listy użytkowniku mimo podania ujemnego limitu', async () => {
       mockPrisma.user.findMany.mockResolvedValue(lista);
       mockPrisma.user.count.mockResolvedValue(3);
 
       const result = await service.searchUsers(1, -3);
-      
+
       expect(result.data).toBe(lista);
 
       expect(result.meta.page).toBe(1);
       expect(result.meta.limit).toBe(1);
       expect(result.meta.total).toBe(3);
       expect(result.meta.totalPages).toBe(3);
-      
-
-     });
+    });
 
     it('Uzyskanie listy użytkowniku wraz z wyszukiwaniem po imieniu', async () => {
       mockPrisma.user.findMany.mockResolvedValue(lista[0]);
       mockPrisma.user.count.mockResolvedValue(1);
 
       const result = await service.searchUsers(1, 2, 'Ign');
-      
+
       expect(result.data).toBe(lista[0]);
 
       expect(result.meta.page).toBe(1);
       expect(result.meta.limit).toBe(2);
       expect(result.meta.total).toBe(1);
       expect(result.meta.totalPages).toBe(1);
-      
-
-     });
-
+    });
   });
-
 
   // makeAdmin
   describe('makeAdmin', () => {
     it('Użytkownik otrzymał uprawnienia administratora', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            is_Admin: false});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        is_Admin: false,
+      });
 
-      mockPrisma.user.update.mockResolvedValue({ id: 1, 
-                                            is_Admin: true});
+      mockPrisma.user.update.mockResolvedValue({ id: 1, is_Admin: true });
 
       const result = await service.makeAdmin(1);
-    
+
       expect(result.id).toBe(1);
       expect(result.is_Admin).toBe(true);
     });
-    
+
     it('Użytkownik będący adminem nie jest modyfikowany', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            is_Admin: true});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        is_Admin: true,
+      });
 
       const result = await service.makeAdmin(1);
-    
+
       expect(result.id).toBe(1);
       expect(result.is_Admin).toBe(true);
     });
-    
+
     it('Nie odnaleziono użytkownika', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
-      
-      await expect(service.makeAdmin(1)).rejects.toThrow(NotFoundException);
-    
-    });
 
+      await expect(service.makeAdmin(1)).rejects.toThrow(NotFoundException);
+    });
   });
 
   // ban
   describe('ban', () => {
     it('Użytkownik został zablokowany', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            is_Banned: false});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        is_Banned: false,
+      });
 
-      mockPrisma.user.update.mockResolvedValue({ id: 1, 
-                                            is_Banned: true});
+      mockPrisma.user.update.mockResolvedValue({ id: 1, is_Banned: true });
 
       const result = await service.ban(1);
-    
+
       expect(result.id).toBe(1);
       expect(result.is_Banned).toBe(true);
     });
-    
+
     it('Użytkownik zablokowany nie jest modyfikowany', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            is_Banned: true});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        is_Banned: true,
+      });
 
       const result = await service.ban(1);
-    
+
       expect(result.id).toBe(1);
       expect(result.is_Banned).toBe(true);
     });
-    
+
     it('Nie odnaleziono użytkownika', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
-      
+
       await expect(service.ban(1)).rejects.toThrow(NotFoundException);
-    
     });
-
   });
-
 
   // unban
   describe('unban', () => {
     it('Użytkownik został odblokowany', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            is_Banned: true});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        is_Banned: true,
+      });
 
-      mockPrisma.user.update.mockResolvedValue({ id: 1, 
-                                            is_Banned: false});
+      mockPrisma.user.update.mockResolvedValue({ id: 1, is_Banned: false });
 
       const result = await service.unban(1);
-    
+
       expect(result.id).toBe(1);
       expect(result.is_Banned).toBe(false);
     });
-    
+
     it('Użytkownik niezablokowany nie jest modyfikowany', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            is_Banned: false});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        is_Banned: false,
+      });
 
       const result = await service.unban(1);
-    
+
       expect(result.id).toBe(1);
       expect(result.is_Banned).toBe(false);
     });
-    
+
     it('Nie odnaleziono użytkownika', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
-      
-      await expect(service.unban(1)).rejects.toThrow(NotFoundException);
-    
-    });
 
+      await expect(service.unban(1)).rejects.toThrow(NotFoundException);
+    });
   });
 
   // updateUser
   describe('updateUser', () => {
-    const dto = {userId: 1,
-        newName: 'Stanisław',
-        newLastname: 'Wokulski',
-        oldPassword: 'hashed',
-        newPassword: 'newhaslo1234',};
+    const dto = {
+      userId: 1,
+      newName: 'Stanisław',
+      newLastname: 'Wokulski',
+      oldPassword: 'hashed',
+      newPassword: 'newhaslo1234',
+    };
 
     it('Dane zostały zmienione', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            password: 'hashed'});
-      mockPrisma.user.update.mockResolvedValue({ id: 1,
-                                            name: dto.newName, 
-                                            lastname: dto.newLastname});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        password: 'hashed',
+      });
+      mockPrisma.user.update.mockResolvedValue({
+        id: 1,
+        name: dto.newName,
+        lastname: dto.newLastname,
+      });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      const result = await service.updateUser(dto.userId, dto.newName, dto.newLastname,
-                                                 dto.oldPassword, dto.newPassword);
-    
+      const result = await service.updateUser(
+        dto.userId,
+        dto.newName,
+        dto.newLastname,
+        dto.oldPassword,
+        dto.newPassword,
+      );
+
       expect(result.id).toBe(dto.userId);
       expect(result.name).toBe(dto.newName);
       expect(result.lastname).toBe(dto.newLastname);
     });
-    
+
     it('Dane zostały zmienione, pomimo podania pustych parametrów nowych danych', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            password: 'hashed'});
-      mockPrisma.user.update.mockResolvedValue({ id: 1,
-                                            name: 'Ignacy', 
-                                            lastname: 'Rzecki'});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        password: 'hashed',
+      });
+      mockPrisma.user.update.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+      });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
 
-      const result = await service.updateUser(dto.userId, '', '',
-                                                 dto.oldPassword, '');
-    
+      const result = await service.updateUser(
+        dto.userId,
+        '',
+        '',
+        dto.oldPassword,
+        '',
+      );
+
       expect(result.id).toBe(dto.userId);
       expect(result.name).toBe('Ignacy');
       expect(result.lastname).toBe('Rzecki');
@@ -340,27 +351,36 @@ describe('UserService', () => {
 
     it('Użytkownik nie istnieje', async () => {
       mockPrisma.user.findUnique.mockResolvedValue(null);
-      
-      await expect(service.updateUser(dto.userId, dto.newName, dto.newLastname,
-                                            dto.oldPassword, dto.newPassword))
-                                            .rejects.toThrow(NotFoundException);
-    
+
+      await expect(
+        service.updateUser(
+          dto.userId,
+          dto.newName,
+          dto.newLastname,
+          dto.oldPassword,
+          dto.newPassword,
+        ),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('Podano niepoprawne hasło', async () => {
-      mockPrisma.user.findUnique.mockResolvedValue({ id: 1, 
-                                            name: 'Ignacy', 
-                                            lastname: "Rzecki", 
-                                            password: 'hashed'});
+      mockPrisma.user.findUnique.mockResolvedValue({
+        id: 1,
+        name: 'Ignacy',
+        lastname: 'Rzecki',
+        password: 'hashed',
+      });
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
 
-      await expect(service.updateUser(dto.userId, dto.newName, dto.newLastname,
-                                            dto.oldPassword, dto.newPassword))
-                                            .rejects.toThrow(UnauthorizedException);
-    
+      await expect(
+        service.updateUser(
+          dto.userId,
+          dto.newName,
+          dto.newLastname,
+          dto.oldPassword,
+          dto.newPassword,
+        ),
+      ).rejects.toThrow(UnauthorizedException);
     });
-    
-    
   });
-
-});   
+});

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -1,0 +1,480 @@
+#!/bin/bash
+
+BASE_URL="http://127.0.0.1:4000"
+COOKIE_JAR="./cookies.txt"
+PASS=0
+FAIL=0
+TIMESTAMP=$(date +%s)
+
+# Dane testowe
+TEST_BOOK_TITLE="test_title_$TIMESTAMP"
+TEST_BOOK_ISBN="978$(echo $TIMESTAMP | tail -c 11)"
+TEST_AUTHOR_NAME="test_name"
+TEST_AUTHOR_LASTNAME="test_lastname_$TIMESTAMP"
+TEST_PUBLISHER="test_publisher_$TIMESTAMP"
+TEST_USER_MAIL="test_user_$TIMESTAMP@test.com"
+TEST_USER_PASSWORD="Test1234!"
+TEST_USER_NAME="test_name_$TIMESTAMP"
+TEST_USER_LASTNAME="test_lastname_$TIMESTAMP"
+
+EXISTING_BOOK_ID=1
+
+rm -f $COOKIE_JAR
+
+check() {
+  local TEST_NAME=$1
+  local EXPECTED=$2
+  local ACTUAL=$3
+  if echo "$ACTUAL" | grep -q "$EXPECTED"; then
+    echo "✓ $TEST_NAME"
+    PASS=$((PASS + 1))
+  else
+    echo "✗ $TEST_NAME"
+    echo "  expected: $EXPECTED"
+    echo "  actual:   $ACTUAL"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+extract() {
+  local KEY=$1
+  local JSON=$2
+  echo $JSON | grep -o "\"$KEY\":[^,}]*" | head -1 | grep -o '[0-9]*' | head -1
+}
+
+extract_str() {
+  local KEY=$1
+  local JSON=$2
+  echo $JSON | grep -o "\"$KEY\":\"[^\"]*\"" | head -1 | sed 's/.*":"//' | sed 's/"//'
+}
+
+# ══════════════════════════════════════════════════════════════
+# HEALTH
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== HEALTH ==="
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/health")
+check "Status serwera" "ok" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# AUTH
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== AUTH ==="
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout")
+check "Wylogowanie nie będąc zalogowanym" "niezalogowany" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -d '{"mail":"zly@email.com","password":"zlehaslo"}')
+check "Logowanie złe dane" "Nieprawidłowy email lub hasło" "$RESPONSE"
+
+REGISTER_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/register" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"mail\":\"$TEST_USER_MAIL\",
+    \"password\":\"$TEST_USER_PASSWORD\",
+    \"name\":\"$TEST_USER_NAME\",
+    \"lastname\":\"$TEST_USER_LASTNAME\"
+  }")
+check "Rejestracja nowego użytkownika" "id" "$REGISTER_RESPONSE"
+TEST_USER_ID=$(extract "id" "$REGISTER_RESPONSE")
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/register" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"mail\":\"$TEST_USER_MAIL\",
+    \"password\":\"$TEST_USER_PASSWORD\",
+    \"name\":\"$TEST_USER_NAME\",
+    \"lastname\":\"$TEST_USER_LASTNAME\"
+  }")
+check "Rejestracja duplikat" "już istnieje" "$RESPONSE"
+
+LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -c $COOKIE_JAR \
+  -d '{"mail":"admin@prisma.io","password":"haslo1234"}')
+check "Logowanie admin" "is_Admin" "$LOGIN_RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout" \
+  -b $COOKIE_JAR \
+  -c $COOKIE_JAR)
+check "Wylogowanie" "success" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# USER — zwykły użytkownik
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== USER (zwykły użytkownik) ==="
+
+LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -c $COOKIE_JAR \
+  -d "{\"mail\":\"$TEST_USER_MAIL\",\"password\":\"$TEST_USER_PASSWORD\"}")
+check "Logowanie zwykły użytkownik" "id" "$LOGIN_RESPONSE"
+
+USER_RESPONSE=$(curl -s -X GET "$BASE_URL/api/user" -b $COOKIE_JAR)
+ORIGINAL_NAME=$(extract_str "name" "$USER_RESPONSE")
+ORIGINAL_LASTNAME=$(extract_str "lastname" "$USER_RESPONSE")
+check "Pobieranie własnych danych" "id" "$USER_RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/user?page=1" \
+  -b $COOKIE_JAR)
+check "Lista użytkowników (brak dostępu)" "administrator" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/user/1" \
+  -b $COOKIE_JAR)
+check "Pobieranie danych innego użytkownika (brak dostępu)" "dostępu" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/user/updateUser" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{
+    \"name\":\"test_newname_$TIMESTAMP\",
+    \"lastname\":\"test_newlastname_$TIMESTAMP\",
+    \"oldpassword\":\"$TEST_USER_PASSWORD\",
+    \"newpassword\":\"\"
+  }")
+check "Aktualizacja danych użytkownika" "id" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/user/updateUser" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d '{
+    "name":"test_name",
+    "lastname":"test_lastname",
+    "oldpassword":"zlehaslo",
+    "newpassword":""
+  }')
+check "Aktualizacja danych (złe hasło)" "Niepoprawne hasło" "$RESPONSE"
+
+# Przywróć oryginalne dane użytkownika
+curl -s -X PATCH "$BASE_URL/api/user/updateUser" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{
+    \"name\":\"$ORIGINAL_NAME\",
+    \"lastname\":\"$ORIGINAL_LASTNAME\",
+    \"oldpassword\":\"$TEST_USER_PASSWORD\",
+    \"newpassword\":\"\"
+  }" >/dev/null
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout" \
+  -b $COOKIE_JAR \
+  -c $COOKIE_JAR)
+check "Wylogowanie zwykły użytkownik" "success" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# USER — admin
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== USER (admin) ==="
+
+LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -c $COOKIE_JAR \
+  -d '{"mail":"admin@prisma.io","password":"haslo1234"}')
+check "Logowanie admin" "id" "$LOGIN_RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/user?page=1&limit=10" \
+  -b $COOKIE_JAR)
+check "Lista użytkowników" "meta" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/user?page=1&limit=10&search=test" \
+  -b $COOKIE_JAR)
+check "Lista użytkowników z wyszukiwaniem" "meta" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/user?page=999&limit=10" \
+  -b $COOKIE_JAR)
+check "Lista użytkowników (strona poza zakresem)" "totalPages" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/user/$TEST_USER_ID" \
+  -b $COOKIE_JAR)
+check "Pobieranie danych użytkownika po id" "id" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/user/999999" \
+  -b $COOKIE_JAR)
+check "Pobieranie danych użytkownika (nie istnieje)" "Nie ma użytkownika o takim id" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/user/$TEST_USER_ID/ban" \
+  -b $COOKIE_JAR)
+check "Zbanowanie użytkownika" "is_Banned" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/user/$TEST_USER_ID/unban" \
+  -b $COOKIE_JAR)
+check "Odbanowanie użytkownika" "is_Banned" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout" \
+  -b $COOKIE_JAR \
+  -c $COOKIE_JAR)
+check "Wylogowanie admin" "success" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# BOOK — publiczne
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== BOOK (publiczne) ==="
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/book")
+check "Lista książek" "meta" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/book?page=1&limit=10")
+check "Lista książek z paginacją" "totalPages" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/book?search=test")
+check "Wyszukiwanie książek" "meta" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/book?page=999&limit=10")
+check "Lista książek (strona poza zakresem)" "totalPages" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/book/$EXISTING_BOOK_ID")
+check "Pobieranie danych książki" "id_book" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/book/999999")
+check "Pobieranie danych książki (nie istnieje)" "nie istnieje" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/book/add" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"title\":\"$TEST_BOOK_TITLE\",
+    \"year\":2000,
+    \"publisher_name\":\"$TEST_PUBLISHER\",
+    \"ISBN\":\"$TEST_BOOK_ISBN\",
+    \"authors\":[{\"author_name\":\"$TEST_AUTHOR_NAME\",\"author_lastname\":\"$TEST_AUTHOR_LASTNAME\"}]
+  }")
+check "Dodanie książki (brak autoryzacji)" "niezalogowany" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# BOOK — admin
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== BOOK (admin) ==="
+
+LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -c $COOKIE_JAR \
+  -d '{"mail":"admin@prisma.io","password":"haslo1234"}')
+check "Logowanie admin" "id" "$LOGIN_RESPONSE"
+
+ADD_BOOK_RESPONSE=$(curl -s -X POST "$BASE_URL/api/book/add" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{
+    \"title\":\"$TEST_BOOK_TITLE\",
+    \"year\":2000,
+    \"cover\":\"https://example.com/test_cover.jpg\",
+    \"publisher_name\":\"$TEST_PUBLISHER\",
+    \"ISBN\":\"$TEST_BOOK_ISBN\",
+    \"authors\":[{\"author_name\":\"$TEST_AUTHOR_NAME\",\"author_lastname\":\"$TEST_AUTHOR_LASTNAME\"}]
+  }")
+check "Dodanie książki" "id_book" "$ADD_BOOK_RESPONSE"
+TEST_BOOK_ID=$(extract "id_book" "$ADD_BOOK_RESPONSE")
+
+BOOK_RESPONSE=$(curl -s -X GET "$BASE_URL/api/book/$TEST_BOOK_ID")
+ORIGINAL_TITLE=$(extract_str "title" "$BOOK_RESPONSE")
+ORIGINAL_YEAR=$(extract "year" "$BOOK_RESPONSE")
+check "Pobieranie danych nowej książki" "id_book" "$BOOK_RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/book/add" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{
+    \"title\":\"$TEST_BOOK_TITLE\",
+    \"year\":2000,
+    \"publisher_name\":\"$TEST_PUBLISHER\",
+    \"ISBN\":\"$TEST_BOOK_ISBN\",
+    \"authors\":[{\"author_name\":\"$TEST_AUTHOR_NAME\",\"author_lastname\":\"$TEST_AUTHOR_LASTNAME\"}]
+  }")
+check "Dodanie książki (duplikat)" "już istnieje" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/book/add" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{
+    \"title\":\"test_title_other_$TIMESTAMP\",
+    \"year\":2000,
+    \"publisher_name\":\"$TEST_PUBLISHER\",
+    \"ISBN\":\"123\",
+    \"authors\":[{\"author_name\":\"$TEST_AUTHOR_NAME\",\"author_lastname\":\"$TEST_AUTHOR_LASTNAME\"}]
+  }")
+check "Dodanie książki (nieprawidłowy ISBN)" "ISBN musi mieć" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/book/update/$TEST_BOOK_ID" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{\"title\":\"test_title_updated_$TIMESTAMP\"}")
+check "Aktualizacja tytułu książki" "id_book" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/book/update/$TEST_BOOK_ID" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{\"authors\":[
+    {\"author_name\":\"$TEST_AUTHOR_NAME\",\"author_lastname\":\"$TEST_AUTHOR_LASTNAME\"},
+    {\"author_name\":\"test_name2\",\"author_lastname\":\"test_lastname2_$TIMESTAMP\"}
+  ]}")
+check "Aktualizacja autorów książki" "id_book" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/book/update/$TEST_BOOK_ID" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{\"publisher_name\":\"test_publisher_new_$TIMESTAMP\"}")
+check "Aktualizacja wydawnictwa książki" "id_book" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/book/update/$TEST_BOOK_ID" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d '{"ISBN":"123"}')
+check "Aktualizacja książki (nieprawidłowy ISBN)" "ISBN musi mieć" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/book/update/999999" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d '{"title":"test_title_updated"}')
+check "Aktualizacja książki (nie istnieje)" "nie istnieje" "$RESPONSE"
+
+# Przywróć oryginalny tytuł i rok
+curl -s -X PATCH "$BASE_URL/api/book/update/$TEST_BOOK_ID" \
+  -H "Content-Type: application/json" \
+  -b $COOKIE_JAR \
+  -d "{\"title\":\"$ORIGINAL_TITLE\",\"year\":$ORIGINAL_YEAR}" >/dev/null
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout" \
+  -b $COOKIE_JAR \
+  -c $COOKIE_JAR)
+check "Wylogowanie admin" "success" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# COPY — admin
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== COPY (admin) ==="
+
+LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -c $COOKIE_JAR \
+  -d '{"mail":"admin@prisma.io","password":"haslo1234"}')
+check "Logowanie admin" "id" "$LOGIN_RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/copy/$EXISTING_BOOK_ID?page=1&limit=10" \
+  -b $COOKIE_JAR)
+check "Lista kopii książki" "meta" "$RESPONSE"
+
+ADD_COPY_RESPONSE=$(curl -s -X POST "$BASE_URL/api/copy/add/$EXISTING_BOOK_ID" \
+  -b $COOKIE_JAR)
+check "Dodanie kopii" "id_copy" "$ADD_COPY_RESPONSE"
+TEST_COPY_ID=$(extract "id_copy" "$ADD_COPY_RESPONSE")
+
+ADD_COPY2_RESPONSE=$(curl -s -X POST "$BASE_URL/api/copy/add/$EXISTING_BOOK_ID" \
+  -b $COOKIE_JAR)
+check "Dodanie drugiej kopii" "id_copy" "$ADD_COPY2_RESPONSE"
+TEST_COPY2_ID=$(extract "id_copy" "$ADD_COPY2_RESPONSE")
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/copy/remove/$TEST_COPY2_ID" \
+  -b $COOKIE_JAR)
+check "Usunięcie kopii" "is_actual" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/copy/remove/$TEST_COPY2_ID" \
+  -b $COOKIE_JAR)
+check "Usunięcie kopii (już usuniętej)" "już usunięta" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout" \
+  -b $COOKIE_JAR \
+  -c $COOKIE_JAR)
+check "Wylogowanie admin" "success" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# LOAN — zwykły użytkownik
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== LOAN (zwykły użytkownik) ==="
+
+LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -c $COOKIE_JAR \
+  -d "{\"mail\":\"$TEST_USER_MAIL\",\"password\":\"$TEST_USER_PASSWORD\"}")
+check "Logowanie zwykły użytkownik" "id" "$LOGIN_RESPONSE"
+
+LOAN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/loan/loanBook/$TEST_COPY_ID" \
+  -b $COOKIE_JAR)
+check "Wypożyczenie książki" "copy_id" "$LOAN_RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/loan/loanBook/$TEST_COPY_ID" \
+  -b $COOKIE_JAR)
+check "Wypożyczenie już wypożyczonej kopii" "już wypożyczona" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/loan/loanBook/$TEST_COPY2_ID" \
+  -b $COOKIE_JAR)
+check "Wypożyczenie usuniętej kopii" "nie istnieje" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/loan/ActiveLoans?page=1&limit=10" \
+  -b $COOKIE_JAR)
+check "Lista aktywnych wypożyczeń" "meta" "$RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/loan/loans" \
+  -b $COOKIE_JAR)
+check "Historia wypożyczeń" "id_loan" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/loan/returnBook/$TEST_COPY_ID" \
+  -b $COOKIE_JAR)
+check "Zwrot książki" "return_date" "$RESPONSE"
+
+RESPONSE=$(curl -s -X PATCH "$BASE_URL/api/loan/returnBook/$TEST_COPY_ID" \
+  -b $COOKIE_JAR)
+check "Zwrot już zwróconej książki" "aktywnego wypożyczenia" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout" \
+  -b $COOKIE_JAR \
+  -c $COOKIE_JAR)
+check "Wylogowanie zwykły użytkownik" "success" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# LOAN — admin
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== LOAN (admin) ==="
+
+LOGIN_RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/login" \
+  -H "Content-Type: application/json" \
+  -c $COOKIE_JAR \
+  -d '{"mail":"admin@prisma.io","password":"haslo1234"}')
+check "Logowanie admin" "id" "$LOGIN_RESPONSE"
+
+RESPONSE=$(curl -s -X GET "$BASE_URL/api/loan/loans/$TEST_USER_ID" \
+  -b $COOKIE_JAR)
+check "Historia wypożyczeń użytkownika (admin)" "id_loan" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# CLEANUP
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "=== CLEANUP ==="
+
+RESPONSE=$(curl -s -X DELETE "$BASE_URL/api/book/delete/$TEST_BOOK_ID" \
+  -b $COOKIE_JAR)
+check "Hard delete książki testowej" "id_book" "$RESPONSE"
+
+# Hard delete użytkownika testowego
+RESPONSE=$(curl -s -X DELETE "$BASE_URL/api/auth/deleteUser/$TEST_USER_ID" \
+  -b $COOKIE_JAR)
+check "Hard delete użytkownika testowego" "id" "$RESPONSE"
+
+RESPONSE=$(curl -s -X POST "$BASE_URL/api/auth/logout" \
+  -b $COOKIE_JAR \
+  -c $COOKIE_JAR)
+check "Wylogowanie admin" "success" "$RESPONSE"
+
+# ══════════════════════════════════════════════════════════════
+# SUMMARY
+# ══════════════════════════════════════════════════════════════
+echo ""
+echo "========================="
+echo "  PASS:  $PASS"
+echo "  FAIL:  $FAIL"
+echo "  TOTAL: $((PASS + FAIL))"
+echo "========================="
+
+rm -f $COOKIE_JAR
+EOF
+chmod +x /mnt/user-data/outputs/test.sh

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -476,5 +476,3 @@ echo "  TOTAL: $((PASS + FAIL))"
 echo "========================="
 
 rm -f $COOKIE_JAR
-EOF
-chmod +x /mnt/user-data/outputs/test.sh


### PR DESCRIPTION
Dodano skrypt testujący istniejące endpointy. Skrypt działa na danych testowych. Dodano enpointy usuwania użytkownika i książek które powinny być wykorzystywane wyłącznie do testów. Dodane endponty nie powinny być implementowane po stronie frontendu

uruchmienie testu w katalogu głównym bash backend/test.sh 

## Opis zmian
<!-- Co zostało zmienione i dlaczego? -->

## Typ zmiany
- [x] feat: nowa funkcjonalność
- [ ] fix: naprawa błędu
- [ ] docs: dokumentacja
- [ ] chore: porządki, konfiguracja
- [ ] refactor: refaktoryzacja kodu

## Jak przetestowano?
<!-- Opisz jak sprawdziłeś/aś że zmiany działają -->

## Checklist
- [x] Kod działa lokalnie
- [x] Brak błędów lint/typecheck
- [ ] Testy przechodzą (jeśli dotyczy)
- [x] Opis PR jest zrozumiały dla reszty zespołu