### PR TITLE
fix: Fixed resolve cascading renders in EditBookModal

### DIFF
--- a/frontend/src/pages/admin/dashboard/components/EditBookModal.tsx
+++ b/frontend/src/pages/admin/dashboard/components/EditBookModal.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import CustomModal from '../../../../ui/CustomModal';
 import { Button } from '../../../../ui/Button';
 import { useBookData } from '../../../../hooks/book/use-book-data';
@@ -13,33 +14,53 @@ type EditBookModalProps = {
 
 function EditBookModal({ bookId, isOpen, onClose }: EditBookModalProps) {
     const { data: bookData, isLoading: isFetching } = useBookData(bookId ?? '');
+
+    const handleClose = () => {
+        onClose();
+    };
+
+    return (
+        <CustomModal isOpened={isOpen} onClose={handleClose} header="" width="550px" bgColor="bg-color-gray-50">
+            <CustomModal.Content className="w-full flex flex-col gap-4 px-6 max-h-[75vh] overflow-y-auto">
+                <h2 className="text-center text-2xl font-bold uppercase text-main-navy-blue tracking-wide mt-2">
+                    Edit Book Details
+                </h2>
+
+                {isFetching ? (
+                    <p className="text-center text-gray-500 py-6 font-medium animate-pulse">Loading book data...</p>
+                ) : bookData ? (
+                    <EditBookModalForm bookId={bookId!} bookData={bookData} onClose={handleClose} />
+                ) : (
+                    <p className="text-center text-red-500 py-6 font-medium">Failed to load book data.</p>
+                )}
+            </CustomModal.Content>
+        </CustomModal>
+    );
+}
+
+type EditBookModalFormProps = {
+    bookId: string;
+    bookData: any; 
+    onClose: () => void;
+};
+
+function EditBookModalForm({ bookId, bookData, onClose }: EditBookModalFormProps) {
+    const queryClient = useQueryClient(); 
     const { mutate: updateBook, isPending: isUpdating } = useUpdateBook();
 
-    const [title, setTitle] = useState('');
-    const [year, setYear] = useState('');
-    const [publisherName, setPublisherName] = useState('');
-    const [cover, setCover] = useState('');
-    const [isbn, setIsbn] = useState('');
+    const [title, setTitle] = useState(bookData.title || '');
+    const [year, setYear] = useState(bookData.year?.toString() || '');
+    const [publisherName, setPublisherName] = useState(bookData.publisherName || '');
+    const [cover, setCover] = useState(bookData.cover || '');
+    const [isbn, setIsbn] = useState(bookData.ISBN || '');
     
-    const [authors, setAuthors] = useState<{ author_name: string; author_lastname: string }[]>([]);
+    const [authors, setAuthors] = useState<{ author_name: string; author_lastname: string }[]>(
+        bookData.authors && bookData.authors.length > 0 
+            ? bookData.authors 
+            : [{ author_name: '', author_lastname: '' }]
+    );
     
     const [errorMsg, setErrorMsg] = useState('');
-
-    useEffect(() => {
-        if (isOpen && bookData) {
-            setTitle(bookData.title || '');
-            setYear(bookData.year?.toString() || '');
-            setPublisherName(bookData.publisherName || ''); 
-            setCover(bookData.cover || '');
-            setIsbn(bookData.ISBN || '');
-            
-            if (bookData.authors && bookData.authors.length > 0) {
-                setAuthors(bookData.authors);
-            } else {
-                setAuthors([{ author_name: '', author_lastname: '' }]);
-            }
-        }
-    }, [bookData, isOpen]);
 
     const handleAddAuthorField = () => {
         setAuthors([...authors, { author_name: '', author_lastname: '' }]);
@@ -57,16 +78,9 @@ function EditBookModal({ bookId, isOpen, onClose }: EditBookModalProps) {
         setAuthors(updatedAuthors);
     };
 
-    const handleClose = () => {
-        setErrorMsg('');
-        onClose();
-    };
-
     const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>) => {
         e.preventDefault();
         setErrorMsg('');
-
-        if (!bookId) return;
 
         if (!title.trim() || !year.trim() || !publisherName.trim()) {
             setErrorMsg('Title, Year and Publisher Name are required.');
@@ -98,7 +112,9 @@ function EditBookModal({ bookId, isOpen, onClose }: EditBookModalProps) {
             },
             {
                 onSuccess: () => {
-                    handleClose();
+                    queryClient.invalidateQueries({ queryKey: ['book', bookId] });
+                    queryClient.invalidateQueries({ queryKey: ['books'] }); 
+                    onClose();
                 },
                 onError: (err: any) => {
                     setErrorMsg(err?.response?.data?.message || 'Something went wrong while updating.');
@@ -107,77 +123,63 @@ function EditBookModal({ bookId, isOpen, onClose }: EditBookModalProps) {
         );
     };
 
-    const isPending = isFetching || isUpdating;
-
     return (
-        <CustomModal isOpened={isOpen} onClose={handleClose} header="" width="550px" bgColor="bg-color-gray-50">
-            <CustomModal.Content className="w-full flex flex-col gap-4 px-6 max-h-[75vh] overflow-y-auto">
-                <h2 className="text-center text-2xl font-bold uppercase text-main-navy-blue tracking-wide mt-2">
-                    Edit Book Details
-                </h2>
+        <>
+            {errorMsg && <p className="text-sm text-red-500 font-semibold text-center bg-red-50 p-2 rounded-lg">{errorMsg}</p>}
 
-                {errorMsg && <p className="text-sm text-red-500 font-semibold text-center bg-red-50 p-2 rounded-lg">{errorMsg}</p>}
+            <div className="flex flex-col gap-1">
+                <label className="text-sm font-semibold text-main-navy-blue">Title *</label>
+                <input type="text" value={title} disabled={isUpdating} onChange={(e) => setTitle(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
+            </div>
 
-                {isFetching ? (
-                    <p className="text-center text-gray-500 py-6 font-medium animate-pulse">Loading book data...</p>
-                ) : (
-                    <>
-                        <div className="flex flex-col gap-1">
-                            <label className="text-sm font-semibold text-main-navy-blue">Title *</label>
-                            <input type="text" value={title} disabled={isPending} onChange={(e) => setTitle(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
-                        </div>
+            <div className="flex flex-col gap-1">
+                <label className="text-sm font-semibold text-main-navy-blue">Publisher Name *</label>
+                <input type="text" value={publisherName} disabled={isUpdating} onChange={(e) => setPublisherName(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
+            </div>
 
-                        <div className="flex flex-col gap-1">
-                            <label className="text-sm font-semibold text-main-navy-blue">Publisher Name *</label>
-                            <input type="text" value={publisherName} disabled={isPending} onChange={(e) => setPublisherName(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
-                        </div>
+            <div className="flex flex-col gap-2 border-t pt-2">
+                <div className="flex justify-between items-center">
+                    <label className="text-sm font-semibold text-main-navy-blue">Authors *</label>
+                    <Button type="button" intent="primary" size="small" onClick={handleAddAuthorField} disabled={isUpdating} className="py-1 px-2 flex items-center gap-1 text-xs">
+                        <Plus className="w-3 h-3" /> Add Author
+                    </Button>
+                </div>
+                {authors.map((author, index) => (
+                    <div key={index} className="flex gap-2 items-center">
+                        <input type="text" value={author.author_name} disabled={isUpdating} onChange={(e) => handleAuthorChange(index, 'author_name', e.target.value)} placeholder="First Name" className="w-1/2 bg-white text-gray-800 text-sm rounded-xl border p-2 outline-none border-gray-300 focus:border-main-blue" />
+                        <input type="text" value={author.author_lastname} disabled={isUpdating} onChange={(e) => handleAuthorChange(index, 'author_lastname', e.target.value)} placeholder="Last Name" className="w-1/2 bg-white text-gray-800 text-sm rounded-xl border p-2 outline-none border-gray-300 focus:border-main-blue" />
+                        {authors.length > 1 && (
+                            <button type="button" onClick={() => handleRemoveAuthorField(index)} className="text-red-500 hover:text-red-700 p-1">
+                                <Trash2 className="w-4 h-4" />
+                            </button>
+                        )}
+                    </div>
+                ))}
+            </div>
 
-                        <div className="flex flex-col gap-2 border-t pt-2">
-                            <div className="flex justify-between items-center">
-                                <label className="text-sm font-semibold text-main-navy-blue">Authors *</label>
-                                <Button type="button" intent="primary" size="small" onClick={handleAddAuthorField} disabled={isPending} className="py-1 px-2 flex items-center gap-1 text-xs">
-                                    <Plus className="w-3 h-3" /> Add Author
-                                </Button>
-                            </div>
-                            {authors.map((author, index) => (
-                                <div key={index} className="flex gap-2 items-center">
-                                    <input type="text" value={author.author_name} disabled={isPending} onChange={(e) => handleAuthorChange(index, 'author_name', e.target.value)} placeholder="First Name" className="w-1/2 bg-white text-gray-800 text-sm rounded-xl border p-2 outline-none border-gray-300 focus:border-main-blue" />
-                                    <input type="text" value={author.author_lastname} disabled={isPending} onChange={(e) => handleAuthorChange(index, 'author_lastname', e.target.value)} placeholder="Last Name" className="w-1/2 bg-white text-gray-800 text-sm rounded-xl border p-2 outline-none border-gray-300 focus:border-main-blue" />
-                                    {authors.length > 1 && (
-                                        <button type="button" onClick={() => handleRemoveAuthorField(index)} className="text-red-500 hover:text-red-700 p-1">
-                                            <Trash2 className="w-4 h-4" />
-                                        </button>
-                                    )}
-                                </div>
-                            ))}
-                        </div>
+            <div className="flex gap-4 border-t pt-2">
+                <div className="flex flex-col gap-1 w-1/2">
+                    <label className="text-sm font-semibold text-main-navy-blue">ISBN (13 digits)</label>
+                    <input type="text" maxLength={13} value={isbn} disabled={isUpdating} onChange={(e) => setIsbn(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
+                </div>
+                <div className="flex flex-col gap-1 w-1/2">
+                    <label className="text-sm font-semibold text-main-navy-blue">Year *</label>
+                    <input type="number" value={year} min="2000" max={new Date().getFullYear()} disabled={isUpdating} onChange={(e) => setYear(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
+                </div>
+            </div>
 
-                        <div className="flex gap-4 border-t pt-2">
-                            <div className="flex flex-col gap-1 w-1/2">
-                                <label className="text-sm font-semibold text-main-navy-blue">ISBN (13 digits)</label>
-                                <input type="text" maxLength={13} value={isbn} disabled={isPending} onChange={(e) => setIsbn(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
-                            </div>
-                            <div className="flex flex-col gap-1 w-1/2">
-                                <label className="text-sm font-semibold text-main-navy-blue">Year *</label>
-                                <input type="number" value={year} min="2000" max={new Date().getFullYear()} disabled={isPending} onChange={(e) => setYear(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
-                            </div>
-                        </div>
+            <div className="flex flex-col gap-1">
+                <label className="text-sm font-semibold text-main-navy-blue">Cover Image URL</label>
+                <input type="text" value={cover} disabled={isUpdating} onChange={(e) => setCover(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
+            </div>
 
-                        <div className="flex flex-col gap-1">
-                            <label className="text-sm font-semibold text-main-navy-blue">Cover Image URL</label>
-                            <input type="text" value={cover} disabled={isPending} onChange={(e) => setCover(e.target.value)} className="w-full bg-white text-gray-800 text-sm rounded-xl border p-2.5 outline-none border-gray-300 focus:border-main-blue" />
-                        </div>
-                    </>
-                )}
-            </CustomModal.Content>
-
-            <CustomModal.Footer className="w-full flex justify-center gap-4 pt-2 pb-6 px-6">
-                <Button intent="third" size="medium" onClick={handleClose} disabled={isPending}>Cancel</Button>
-                <Button intent="secondary" size="medium" onClick={handleSubmit} disabled={isPending}>
+            <div className="w-full flex justify-center gap-4 pt-4 mt-2 border-t">
+                <Button intent="third" size="medium" type="button" onClick={onClose} disabled={isUpdating}>Cancel</Button>
+                <Button intent="secondary" size="medium" type="button" onClick={handleSubmit} disabled={isUpdating}>
                     {isUpdating ? 'Saving...' : 'Save Changes'}
                 </Button>
-            </CustomModal.Footer>
-        </CustomModal>
+            </div>
+        </>
     );
 }
 

--- a/frontend/src/pages/admin/dashboard/page.tsx
+++ b/frontend/src/pages/admin/dashboard/page.tsx
@@ -1,29 +1,29 @@
-import { useState } from 'react'; 
+import { useState } from 'react';
 import { Button } from "../../../ui/Button";
 import FilterOptions from "./components/FilterOptions";
 import SearchInput from "./components/SearchInput";
 import SortDropdown from "./components/SortDropdown";
-import AddBookModal from "./components/AddBookModal"; 
-import EditBookModal from "./components/EditBookModal"; 
+import AddBookModal from "./components/AddBookModal";
+import EditBookModal from "./components/EditBookModal";
 import { Plus } from 'lucide-react';
 
 function ADashboard() {
     const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-    
+
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [selectedEditBookId, setSelectedEditBookId] = useState<string | null>(null);
 
     return (
         <>
             <SearchInput placeholder="Search by title or author . . ." />
-            
+
             <div className="flex flex-col md:flex-row items-center gap-4 mt-4 w-full">
                 <FilterOptions />
                 <SortDropdown />
-                
-                <Button 
-                    intent="primary" 
-                    size="medium" 
+
+                <Button
+                    intent="primary"
+                    size="medium"
                     className="flex items-center justify-center gap-2 w-full md:w-auto ml-auto"
                     onClick={() => setIsAddModalOpen(true)}
                 >
@@ -32,19 +32,22 @@ function ADashboard() {
                 </Button>
             </div>
 
-            <AddBookModal 
-                isOpen={isAddModalOpen} 
-                onClose={() => setIsAddModalOpen(false)} 
+            <AddBookModal
+                isOpen={isAddModalOpen}
+                onClose={() => setIsAddModalOpen(false)}
             />
 
-            <EditBookModal 
-                bookId={selectedEditBookId}
-                isOpen={isEditModalOpen}
-                onClose={() => {
-                    setIsEditModalOpen(false);
-                    setSelectedEditBookId(null);
-                }}
-            />
+            {isEditModalOpen && selectedEditBookId && (
+                <EditBookModal
+                    key={selectedEditBookId}
+                    bookId={selectedEditBookId}
+                    isOpen={isEditModalOpen}
+                    onClose={() => {
+                        setIsEditModalOpen(false);
+                        setSelectedEditBookId(null);
+                    }}
+                />
+            )}
         </>
     );
 }


### PR DESCRIPTION
## Opis zmian
- Przebudowano komponent `EditBookModal` poprzez wydzielenie formularza edycji do wewnętrznego komponentu `EditBookModalForm`.
- Usunięto synchroniczne wywołania `setState` z hooka `useEffect`, które powodowały błąd lintera `react-hooks/set-state-in-effect` (cascading renders).

## Typ zmiany
- [ ] feat: nowa funkcjonalność
- [x] fix: naprawa błędu
- [ ] docs: dokumentacja
- [ ] chore: porządki, konfiguracja
- [x] refactor: refaktoryzacja kodu

## Jak przetestowano?
- Zweryfikowano działanie lintera lokalnie za pomocą komendy `npm run lint --prefix frontend` – błąd dotyczący kaskadowych renderów został wyeliminowany.
- Przetestowano manualnie proces edycji książki, w szczególności dodawanie nowych autorów. Dane po zapisaniu są od razu prawidłowo cashowane i widoczne przy ponownym otwarciu modala.

## Checklist
- [x] Kod działa lokalnie
- [x] Brak błędów lint/typecheck
- [x] Testy przechodzą (jeśli dotyczy)
- [x] Opis PR jest zrozumiały dla reszty zespołu